### PR TITLE
🐛Documentation is `text/markdown`; not `text/md`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = Hochfrequenz Unternehmensberatung GmbH
 author_email = info@hochfrequenz.de
 description = Converts (already scraped) Entscheidungsbaumdiagramm tables to real graphs
 long_description = file: README.md
-long_description_content_type = text/md; charset=UTF-8
+long_description_content_type = text/markdown; charset=UTF-8
 url = https://github.com/Hochfrequenz/ebd_table_to_graph
 project_urls =
     Documentation = https://github.com/Hochfrequenz/ebd_table_to_graph


### PR DESCRIPTION
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         'text/md; charset=UTF-8' is an invalid value for                       
         Description-Content-Type. Error: Invalid description content type:     
         type/subtype is not valid See                                          
         https://packaging.python.org/specifications/core-metadata for more     
         information.