### PR TITLE
fix: remove `'` single quote before `labelloc` in dot code

### DIFF
--- a/src/rebdhuhn/graphviz.py
+++ b/src/rebdhuhn/graphviz.py
@@ -160,7 +160,7 @@ def convert_graph_to_dot(ebd_graph: EbdGraph) -> str:
         f'<B><FONT POINT-SIZE="18">{ebd_graph.metadata.chapter}</FONT></B><BR/><BR/>'
         f'<B><FONT POINT-SIZE="16">{ebd_graph.metadata.section}</FONT></B><BR/><BR/><BR/><BR/>'
     )
-    dot_attributes: dict[str, str] = {f"labelloc": '"t"', "label": f"<{header}>"}
+    dot_attributes: dict[str, str] = {"labelloc": '"t"', "label": f"<{header}>"}
     dot_code = "digraph D {\n"
     for dot_attr_key, dot_attr_value in dot_attributes.items():
         dot_code += f"{ADD_INDENT}{dot_attr_key}={dot_attr_value};\n"


### PR DESCRIPTION
caused by: #283 

https://github.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/pull/29/files#diff-e136ab5d15f9e7f9cb04b7e70acdb3a6538c710bce79c452a6f059c36846cac1