### PR TITLE
feat: set background colour to pastell blau (similar to website)

### DIFF
--- a/src/rebdhuhn/add_watermark.py
+++ b/src/rebdhuhn/add_watermark.py
@@ -59,7 +59,7 @@ def add_background(svg: str) -> str:
     :param svg:
     """
     ebd_width_in_px, ebd_height_in_px = get_dimensions_of_svg(BytesIO(svg.encode("utf-8")))
-    background_color = "#f3f1f6"
+    background_color = "#c2cee9"
     tree = etree.parse(BytesIO(svg.encode("utf-8")))  # pylint:disable=c-extension-no-member
     root = tree.getroot()
     xml_element = etree.Element(  # pylint:disable=c-extension-no-member

--- a/unittests/output/E_0003.dot.svg
+++ b/unittests/output/E_0003.dot.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1402.6666666666667px" viewBox="0 0 1402.6666666666667 570.6666666666666" height="570.6666666666666px">
   <g>
     <svg version="1.1" width="1402.6666666666667px" viewBox="0 0 1402.6666666666667 570.6666666666666" height="570.6666666666666px">
-  <polygon fill="#f3f1f6" points="0,0 1402.6666666666667,0 1402.6666666666667,570.6666666666666 0,570.6666666666666"/><g>
+  <polygon fill="#c2cee9" points="0,0 1402.6666666666667,0 1402.6666666666667,570.6666666666666 0,570.6666666666666"/><g>
     <g transform="translate(468.6151131136769, 57.06666666666665) scale(1 1) translate(0, 0) scale(0.8035295222003191 0.8035295222003191) "><!-- note that I manually added the width and height attribute to the root node
   https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
   -->

--- a/unittests/output/E_0003_with_watermark_background_is_True.dot.svg
+++ b/unittests/output/E_0003_with_watermark_background_is_True.dot.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1402.6666666666667px" viewBox="0 0 1402.6666666666667 570.6666666666666" height="570.6666666666666px">
   <g>
     <svg version="1.1" width="1402.6666666666667px" viewBox="0 0 1402.6666666666667 570.6666666666666" height="570.6666666666666px">
-  <polygon fill="#f3f1f6" points="0,0 1402.6666666666667,0 1402.6666666666667,570.6666666666666 0,570.6666666666666"/><g>
+  <polygon fill="#c2cee9" points="0,0 1402.6666666666667,0 1402.6666666666667,570.6666666666666 0,570.6666666666666"/><g>
     <g transform="translate(468.6151131136769, 57.06666666666665) scale(1 1) translate(0, 0) scale(0.8035295222003191 0.8035295222003191) "><!-- note that I manually added the width and height attribute to the root node
   https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
   -->

--- a/unittests/output/E_0015.dot.svg
+++ b/unittests/output/E_0015.dot.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1878.6666666666667px" viewBox="0 0 1878.6666666666667 1826.6666666666667" height="1826.6666666666667px">
   <g>
     <svg version="1.1" width="1878.6666666666667px" viewBox="0 0 1878.6666666666667 1826.6666666666667" height="1826.6666666666667px">
-  <polygon fill="#f3f1f6" points="0,0 1878.6666666666667,0 1878.6666666666667,1826.6666666666667 0,1826.6666666666667"/><g>
+  <polygon fill="#c2cee9" points="0,0 1878.6666666666667,0 1878.6666666666667,1826.6666666666667 0,1826.6666666666667"/><g>
     <g transform="translate(194.41753496667593, 182.66666666666663) scale(1 1) translate(0, 0) scale(2.5720454332113025 2.5720454332113025) "><!-- note that I manually added the width and height attribute to the root node
   https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
   -->

--- a/unittests/output/E_0025.dot.svg
+++ b/unittests/output/E_0025.dot.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1388.0px" viewBox="0 0 1388.0 870.6666666666666" height="870.6666666666666px">
   <g>
     <svg version="1.1" width="1388.0px" viewBox="0 0 1388.0 870.6666666666666" height="870.6666666666666px">
-  <polygon fill="#f3f1f6" points="0,0 1388.0,0 1388.0,870.6666666666666 0,870.6666666666666"/><g>
+  <polygon fill="#c2cee9" points="0,0 1388.0,0 1388.0,870.6666666666666 0,870.6666666666666"/><g>
     <g transform="translate(338.94159391720643, 87.06666666666665) scale(1 1) translate(0, 0) scale(1.2259457429831973 1.2259457429831973) "><!-- note that I manually added the width and height attribute to the root node
   https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
   -->

--- a/unittests/output/E_0401.dot.svg
+++ b/unittests/output/E_0401.dot.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1920.0px" viewBox="0 0 1920.0 1660.0" height="1660.0px">
   <g>
     <svg version="1.1" width="1920.0px" viewBox="0 0 1920.0 1660.0" height="1660.0px">
-  <polygon fill="#f3f1f6" points="0,0 1920.0,0 1920.0,1660.0 0,1660.0"/><g>
+  <polygon fill="#c2cee9" points="0,0 1920.0,0 1920.0,1660.0 0,1660.0"/><g>
     <g transform="translate(283.0509715573078, 165.99999999999997) scale(1 1) translate(0, 0) scale(2.337369754998592 2.337369754998592) "><!-- note that I manually added the width and height attribute to the root node
   https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
   -->


### PR DESCRIPTION
I know, we could just make it transparent, but then, if users download the SVG, the watermark (now all white) would be effectivly gone.
let's hope, nobody's gonna print this :P
