### PR TITLE
fix: ende with different notes but no code

### DIFF
--- a/unittests/__snapshots__/test_table_to_graph.ambr
+++ b/unittests/__snapshots__/test_table_to_graph.ambr
@@ -1217,6 +1217,369 @@
   </svg>
   '''
 # ---
+# name: TestEbdTableModels.test_table_to_digraph_dot_real_kroki_request[table4-DiGraph with 20 nodes and 19 edges][test_table_to_digraph_dot_real_kroki_request_E_0267_Prüfen, ob Antwort auf Stornierung erforderlich]
+  '''
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1428pt" height="1317pt" viewBox="0.00 0.00 1428.05 1316.77">
+  <!--curl - -request POST - -url https://kroki.io/ via local kroki docker container instance hosted at http://localhost:8125/- -header 'Content-Type: application/json' - -data 'digraph D {
+      labelloc="t";
+      label=<<B><FONT POINT-SIZE="18">WiM Strom</FONT></B><BR align="left"/><BR/><B><FONT POINT-SIZE="16">8.27.4: AD: Abrechnung einer f&#252;r den ESA erbrachten Leistung</FONT></B><BR align="left"/><BR/><BR/><BR/>>;
+      ratio="compress";
+      concentrate=true;
+      pack=true;
+      rankdir=TB;
+      packmode="array";
+      size="20,20";
+      fontsize=12;
+      "Start" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#8ba2d7", label=<<B>E_0267</B><BR align="left"/><FONT>Pr&#252;fende Rolle: <B>ESA</B></FONT><BR align="center"/>>, fontname="Roboto, sans-serif"];
+      "10" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>10: </B>Ist die zu stornierende Rechnung beim Empf&#228;nger bekannt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A01" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A01</B><BR align="left"/><BR align="left"/><FONT>Die zu stornierende Rechnung ist nicht vorhanden.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "15" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>15: </B>Liegt vom Rechnungssteller die in dieser Rechnung verwendete Rechnungsnummer<BR align="left"/>bereits vor?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A06" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A06</B><BR align="left"/><BR align="left"/><FONT>Rechnungsnummer wurde bereits verwendet.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "20" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>20: </B>Wurde die zu stornierende Rechnung bereits storniert?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A02" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A02</B><BR align="left"/><BR align="left"/><FONT>Die zu stornierende Rechnung wurde bereits storniert.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "30" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>30: </B>Ist der Rechnungstyp der Stornorechnung identisch mit dem Rechnungstyp der<BR align="left"/>urspr&#252;nglichen Rechnung?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A03" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A03</B><BR align="left"/><BR align="left"/><FONT>Der Rechnungstyp der Stornorechnung ist nicht identisch mit dem Rechnungstyp<BR align="left"/>der urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "40" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>40: </B>Ist der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung<BR align="left"/>identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der<BR align="left"/>urspr&#252;nglichen Rechnung?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A04" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A04</B><BR align="left"/><BR align="left"/><FONT>Der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung ist nicht<BR align="left"/>identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der<BR align="left"/>urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "50" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>50: </B>Entsprechen die Betr&#228;ge der Stornorechnung den Betr&#228;gen der urspr&#252;nglichen Rechnung?<BR align="left"/>Hinweis: Alle MOA-Segmente im Summenteil m&#252;ssen unter Nutzung der<BR align="left"/>Absolutbetragfunktion &#252;bereinstimmen.<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A05" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A05</B><BR align="left"/><BR align="left"/><FONT>Mindestens ein Betrag der Stornorechnung ist nicht identisch mit dem Betrag der<BR align="left"/>urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "60" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>60: </B>Ist ein zuvor nicht spezifizierter Fehler aufgetreten?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "A99" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A99</B><BR align="left"/><BR align="left"/><FONT>Ablehnung Sonstiges<BR align="left"/>Hinweis: Das identifizierte Problem ist in der Antwort zu beschreiben/benennen.<BR align="left"/>Nutzungsm&#246;glichkeit Ende: 01.04.2026 00:00 Uhr<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "70" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>70: </B>Wurde der urspr&#252;nglichen Rechnung zugestimmt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "80" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>80: </B>Wurde die urspr&#252;ngliche Rechnung abgelehnt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+      "Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Hinweis:<BR align="left"/>Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann<BR align="left"/>ist auf die Stornorechnung keine Antwort zu senden<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+      "Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden." [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Hinweis:<BR align="left"/>Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem<BR align="left"/>Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung<BR align="left"/>noch auf die Stornorechnung eine Antwort zu senden.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+  
+      "Start" -> "10" [color="#88a0d6"];
+      "10" -> "A01" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "10" -> "15" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "15" -> "A06" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "15" -> "20" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "20" -> "A02" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "20" -> "30" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "30" -> "A03" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "30" -> "40" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "40" -> "A04" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "40" -> "50" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "50" -> "A05" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "50" -> "60" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "60" -> "A99" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "60" -> "70" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "70" -> "Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "70" -> "80" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "80" -> "Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+      "80" -> "Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden." [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+  
+      bgcolor="transparent";
+  fontname="Roboto, sans-serif";
+  }'--><g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 1312.77)">
+  <title>D</title>
+  <text text-anchor="start" x="428.03" y="-1288.67" font-family="Roboto, sans-serif" font-weight="bold" font-size="18.00">WiM Strom</text>
+  <text text-anchor="start" x="428.03" y="-1260.57" font-family="Roboto, sans-serif" font-weight="bold" font-size="16.00">8.27.4: AD: Abrechnung einer f&#252;r den ESA erbrachten Leistung</text>
+  <!-- Start -->
+  <g id="node1" class="node">
+  <title>Start</title>
+  <path fill="#8ba2d7" stroke="black" stroke-width="0" d="M313.8,-1218.77C313.8,-1218.77 169.5,-1218.77 169.5,-1218.77 163.5,-1218.77 157.5,-1212.77 157.5,-1206.77 157.5,-1206.77 157.5,-1185.49 157.5,-1185.49 157.5,-1179.49 163.5,-1173.49 169.5,-1173.49 169.5,-1173.49 313.8,-1173.49 313.8,-1173.49 319.8,-1173.49 325.8,-1179.49 325.8,-1185.49 325.8,-1185.49 325.8,-1206.77 325.8,-1206.77 325.8,-1212.77 319.8,-1218.77 313.8,-1218.77"/>
+  <text text-anchor="start" x="171.9" y="-1197.83" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">E_0267</text>
+  <text text-anchor="start" x="171.9" y="-1183.83" font-family="Roboto, sans-serif" font-size="14.00">Pr&#252;fende Rolle: </text>
+  <text text-anchor="start" x="281.4" y="-1183.83" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">ESA</text>
+  </g>
+  <!-- 10 -->
+  <g id="node2" class="node">
+  <title>10</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M467.93,-1136.49C467.93,-1136.49 15.38,-1136.49 15.38,-1136.49 9.38,-1136.49 3.38,-1130.49 3.38,-1124.49 3.38,-1124.49 3.38,-1112.49 3.38,-1112.49 3.38,-1106.49 9.38,-1100.49 15.38,-1100.49 15.38,-1100.49 467.93,-1100.49 467.93,-1100.49 473.93,-1100.49 479.93,-1106.49 479.93,-1112.49 479.93,-1112.49 479.93,-1124.49 479.93,-1124.49 479.93,-1130.49 473.93,-1136.49 467.93,-1136.49"/>
+  <text text-anchor="start" x="17.78" y="-1114.82" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">10: </text>
+  <text text-anchor="start" x="47.03" y="-1114.82" font-family="Roboto, sans-serif" font-size="14.00">Ist die zu stornierende Rechnung beim Empf&#228;nger bekannt?</text>
+  </g>
+  <!-- Start&#45;&gt;10 -->
+  <g id="edge1" class="edge">
+  <title>Start-&gt;10</title>
+  <path fill="none" stroke="#88a0d6" d="M241.65,-1173.66C241.65,-1165.58 241.65,-1156.28 241.65,-1147.68"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="245.15,-1147.72 241.65,-1137.72 238.15,-1147.72 245.15,-1147.72"/>
+  </g>
+  <!-- A01 -->
+  <g id="node3" class="node">
+  <title>A01</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M369.3,-1047.24C369.3,-1047.24 12,-1047.24 12,-1047.24 6,-1047.24 0,-1041.24 0,-1035.24 0,-1035.24 0,-999.96 0,-999.96 0,-993.96 6,-987.96 12,-987.96 12,-987.96 369.3,-987.96 369.3,-987.96 375.3,-987.96 381.3,-993.96 381.3,-999.96 381.3,-999.96 381.3,-1035.24 381.3,-1035.24 381.3,-1041.24 375.3,-1047.24 369.3,-1047.24"/>
+  <text text-anchor="start" x="14.4" y="-1026.3" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A01</text>
+  <text text-anchor="start" x="14.4" y="-998.3" font-family="Roboto, sans-serif" font-size="14.00">Die zu stornierende Rechnung ist nicht vorhanden.</text>
+  </g>
+  <!-- 10&#45;&gt;A01 -->
+  <g id="edge2" class="edge">
+  <title>10-&gt;A01</title>
+  <path fill="none" stroke="#88a0d6" d="M233,-1100.71C226.86,-1088.81 218.35,-1072.32 210.58,-1057.24"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="213.74,-1055.73 206.04,-1048.45 207.52,-1058.94 213.74,-1055.73"/>
+  <text text-anchor="start" x="221.65" y="-1070.19" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- 15 -->
+  <g id="node4" class="node">
+  <title>15</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1029.8,-1040.24C1029.8,-1040.24 411.5,-1040.24 411.5,-1040.24 405.5,-1040.24 399.5,-1034.24 399.5,-1028.24 399.5,-1028.24 399.5,-1006.96 399.5,-1006.96 399.5,-1000.96 405.5,-994.96 411.5,-994.96 411.5,-994.96 1029.8,-994.96 1029.8,-994.96 1035.8,-994.96 1041.8,-1000.96 1041.8,-1006.96 1041.8,-1006.96 1041.8,-1028.24 1041.8,-1028.24 1041.8,-1034.24 1035.8,-1040.24 1029.8,-1040.24"/>
+  <text text-anchor="start" x="413.9" y="-1019.3" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">15: </text>
+  <text text-anchor="start" x="443.15" y="-1019.3" font-family="Roboto, sans-serif" font-size="14.00">Liegt vom Rechnungssteller die in dieser Rechnung verwendete Rechnungsnummer</text>
+  <text text-anchor="start" x="413.9" y="-1005.3" font-family="Roboto, sans-serif" font-size="14.00">bereits vor?</text>
+  </g>
+  <!-- 10&#45;&gt;15 -->
+  <g id="edge3" class="edge">
+  <title>10-&gt;15</title>
+  <path fill="none" stroke="#88a0d6" d="M323.99,-1100.49C401.38,-1084.51 517.97,-1060.44 604.74,-1042.53"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="605.4,-1045.97 614.49,-1040.52 603.99,-1039.11 605.4,-1045.97"/>
+  <text text-anchor="start" x="480.65" y="-1070.19" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- A06 -->
+  <g id="node5" class="node">
+  <title>A06</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M522.05,-934.71C522.05,-934.71 199.25,-934.71 199.25,-934.71 193.25,-934.71 187.25,-928.71 187.25,-922.71 187.25,-922.71 187.25,-887.43 187.25,-887.43 187.25,-881.43 193.25,-875.43 199.25,-875.43 199.25,-875.43 522.05,-875.43 522.05,-875.43 528.05,-875.43 534.05,-881.43 534.05,-887.43 534.05,-887.43 534.05,-922.71 534.05,-922.71 534.05,-928.71 528.05,-934.71 522.05,-934.71"/>
+  <text text-anchor="start" x="201.65" y="-913.77" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A06</text>
+  <text text-anchor="start" x="201.65" y="-885.77" font-family="Roboto, sans-serif" font-size="14.00">Rechnungsnummer wurde bereits verwendet.</text>
+  </g>
+  <!-- 15&#45;&gt;A06 -->
+  <g id="edge4" class="edge">
+  <title>15-&gt;A06</title>
+  <path fill="none" stroke="#88a0d6" d="M650.38,-995.03C597.6,-978.82 524.47,-956.37 464.88,-938.07"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="465.95,-934.74 455.37,-935.15 463.9,-941.43 465.95,-934.74"/>
+  <text text-anchor="start" x="561.65" y="-957.66" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- 20 -->
+  <g id="node6" class="node">
+  <title>20</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M977.42,-923.07C977.42,-923.07 563.88,-923.07 563.88,-923.07 557.88,-923.07 551.88,-917.07 551.88,-911.07 551.88,-911.07 551.88,-899.07 551.88,-899.07 551.88,-893.07 557.88,-887.07 563.88,-887.07 563.88,-887.07 977.42,-887.07 977.42,-887.07 983.42,-887.07 989.42,-893.07 989.42,-899.07 989.42,-899.07 989.42,-911.07 989.42,-911.07 989.42,-917.07 983.42,-923.07 977.42,-923.07"/>
+  <text text-anchor="start" x="566.27" y="-901.39" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">20: </text>
+  <text text-anchor="start" x="595.52" y="-901.39" font-family="Roboto, sans-serif" font-size="14.00">Wurde die zu stornierende Rechnung bereits storniert?</text>
+  </g>
+  <!-- 15&#45;&gt;20 -->
+  <g id="edge5" class="edge">
+  <title>15-&gt;20</title>
+  <path fill="none" stroke="#88a0d6" d="M730.41,-995.03C738.39,-977.38 749.73,-952.32 758.33,-933.3"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="761.48,-934.83 762.42,-924.27 755.1,-931.94 761.48,-934.83"/>
+  <text text-anchor="start" x="747.65" y="-957.66" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- A02 -->
+  <g id="node7" class="node">
+  <title>A02</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M483.92,-822.18C483.92,-822.18 103.38,-822.18 103.38,-822.18 97.38,-822.18 91.37,-816.18 91.37,-810.18 91.37,-810.18 91.37,-774.9 91.37,-774.9 91.37,-768.9 97.37,-762.9 103.37,-762.9 103.37,-762.9 483.92,-762.9 483.92,-762.9 489.92,-762.9 495.92,-768.9 495.92,-774.9 495.92,-774.9 495.92,-810.18 495.92,-810.18 495.92,-816.18 489.92,-822.18 483.92,-822.18"/>
+  <text text-anchor="start" x="105.77" y="-801.24" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A02</text>
+  <text text-anchor="start" x="105.77" y="-773.24" font-family="Roboto, sans-serif" font-size="14.00">Die zu stornierende Rechnung wurde bereits storniert.</text>
+  </g>
+  <!-- 20&#45;&gt;A02 -->
+  <g id="edge6" class="edge">
+  <title>20-&gt;A02</title>
+  <path fill="none" stroke="#88a0d6" d="M697.42,-887.1C625.92,-870.53 515.43,-844.93 428.09,-824.69"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="429.03,-821.32 418.49,-822.47 427.45,-828.14 429.03,-821.32"/>
+  <text text-anchor="start" x="560.65" y="-845.13" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- 30 -->
+  <g id="node8" class="node">
+  <title>30</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1113.8,-815.18C1113.8,-815.18 525.5,-815.18 525.5,-815.18 519.5,-815.18 513.5,-809.18 513.5,-803.18 513.5,-803.18 513.5,-781.9 513.5,-781.9 513.5,-775.9 519.5,-769.9 525.5,-769.9 525.5,-769.9 1113.8,-769.9 1113.8,-769.9 1119.8,-769.9 1125.8,-775.9 1125.8,-781.9 1125.8,-781.9 1125.8,-803.18 1125.8,-803.18 1125.8,-809.18 1119.8,-815.18 1113.8,-815.18"/>
+  <text text-anchor="start" x="527.9" y="-794.24" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">30: </text>
+  <text text-anchor="start" x="557.15" y="-794.24" font-family="Roboto, sans-serif" font-size="14.00">Ist der Rechnungstyp der Stornorechnung identisch mit dem Rechnungstyp der</text>
+  <text text-anchor="start" x="527.9" y="-780.24" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung?</text>
+  </g>
+  <!-- 20&#45;&gt;30 -->
+  <g id="edge7" class="edge">
+  <title>20-&gt;30</title>
+  <path fill="none" stroke="#88a0d6" d="M778.09,-887.28C785.35,-870.9 796.59,-845.57 805.54,-825.36"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="808.65,-826.99 809.5,-816.43 802.25,-824.16 808.65,-826.99"/>
+  <text text-anchor="start" x="797.65" y="-845.13" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- A03 -->
+  <g id="node9" class="node">
+  <title>A03</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M613.17,-709.65C613.17,-709.65 42.12,-709.65 42.12,-709.65 36.12,-709.65 30.12,-703.65 30.12,-697.65 30.12,-697.65 30.12,-648.37 30.12,-648.37 30.12,-642.37 36.12,-636.37 42.12,-636.37 42.12,-636.37 613.17,-636.37 613.17,-636.37 619.17,-636.37 625.17,-642.37 625.17,-648.37 625.17,-648.37 625.17,-697.65 625.17,-697.65 625.17,-703.65 619.17,-709.65 613.17,-709.65"/>
+  <text text-anchor="start" x="44.52" y="-688.71" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A03</text>
+  <text text-anchor="start" x="44.52" y="-660.71" font-family="Roboto, sans-serif" font-size="14.00">Der Rechnungstyp der Stornorechnung ist nicht identisch mit dem Rechnungstyp</text>
+  <text text-anchor="start" x="44.52" y="-646.71" font-family="Roboto, sans-serif" font-size="14.00">der urspr&#252;nglichen Rechnung.</text>
+  </g>
+  <!-- 30&#45;&gt;A03 -->
+  <g id="edge8" class="edge">
+  <title>30-&gt;A03</title>
+  <path fill="none" stroke="#88a0d6" d="M729.12,-769.91C661.66,-753.8 567.77,-731.37 487.75,-712.25"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="488.57,-708.85 478.03,-709.93 486.94,-715.66 488.57,-708.85"/>
+  <text text-anchor="start" x="617.65" y="-732.6" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- 40 -->
+  <g id="node10" class="node">
+  <title>40</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1240.3,-702.65C1240.3,-702.65 655,-702.65 655,-702.65 649,-702.65 643,-696.65 643,-690.65 643,-690.65 643,-655.37 643,-655.37 643,-649.37 649,-643.37 655,-643.37 655,-643.37 1240.3,-643.37 1240.3,-643.37 1246.3,-643.37 1252.3,-649.37 1252.3,-655.37 1252.3,-655.37 1252.3,-690.65 1252.3,-690.65 1252.3,-696.65 1246.3,-702.65 1240.3,-702.65"/>
+  <text text-anchor="start" x="657.4" y="-681.71" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">40: </text>
+  <text text-anchor="start" x="686.65" y="-681.71" font-family="Roboto, sans-serif" font-size="14.00">Ist der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung</text>
+  <text text-anchor="start" x="657.4" y="-667.71" font-family="Roboto, sans-serif" font-size="14.00">identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der</text>
+  <text text-anchor="start" x="657.4" y="-653.71" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung?</text>
+  </g>
+  <!-- 30&#45;&gt;40 -->
+  <g id="edge9" class="edge">
+  <title>30-&gt;40</title>
+  <path fill="none" stroke="#88a0d6" d="M843.13,-769.98C861.35,-753.25 887.02,-729.68 908.36,-710.09"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="910.48,-712.89 915.48,-703.55 905.75,-707.73 910.48,-712.89"/>
+  <text text-anchor="start" x="886.65" y="-732.6" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- A04 -->
+  <g id="node11" class="node">
+  <title>A04</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M651.55,-583.12C651.55,-583.12 55.75,-583.12 55.75,-583.12 49.75,-583.12 43.75,-577.12 43.75,-571.12 43.75,-571.12 43.75,-507.84 43.75,-507.84 43.75,-501.84 49.75,-495.84 55.75,-495.84 55.75,-495.84 651.55,-495.84 651.55,-495.84 657.55,-495.84 663.55,-501.84 663.55,-507.84 663.55,-507.84 663.55,-571.12 663.55,-571.12 663.55,-577.12 657.55,-583.12 651.55,-583.12"/>
+  <text text-anchor="start" x="58.15" y="-562.18" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A04</text>
+  <text text-anchor="start" x="58.15" y="-534.18" font-family="Roboto, sans-serif" font-size="14.00">Der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung ist nicht</text>
+  <text text-anchor="start" x="58.15" y="-520.18" font-family="Roboto, sans-serif" font-size="14.00">identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der</text>
+  <text text-anchor="start" x="58.15" y="-506.18" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung.</text>
+  </g>
+  <!-- 40&#45;&gt;A04 -->
+  <g id="edge10" class="edge">
+  <title>40-&gt;A04</title>
+  <path fill="none" stroke="#88a0d6" d="M818.39,-643.39C742.05,-626.48 643.71,-604.71 557.17,-585.54"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="558.13,-582.17 547.61,-583.43 556.61,-589.01 558.13,-582.17"/>
+  <text text-anchor="start" x="703.65" y="-606.07" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- 50 -->
+  <g id="node12" class="node">
+  <title>50</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1361.55,-569.12C1361.55,-569.12 693.75,-569.12 693.75,-569.12 687.75,-569.12 681.75,-563.12 681.75,-557.12 681.75,-557.12 681.75,-521.84 681.75,-521.84 681.75,-515.84 687.75,-509.84 693.75,-509.84 693.75,-509.84 1361.55,-509.84 1361.55,-509.84 1367.55,-509.84 1373.55,-515.84 1373.55,-521.84 1373.55,-521.84 1373.55,-557.12 1373.55,-557.12 1373.55,-563.12 1367.55,-569.12 1361.55,-569.12"/>
+  <text text-anchor="start" x="696.15" y="-548.18" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">50: </text>
+  <text text-anchor="start" x="725.4" y="-548.18" font-family="Roboto, sans-serif" font-size="14.00">Entsprechen die Betr&#228;ge der Stornorechnung den Betr&#228;gen der urspr&#252;nglichen Rechnung?</text>
+  <text text-anchor="start" x="696.15" y="-534.18" font-family="Roboto, sans-serif" font-size="14.00">Hinweis: Alle MOA-Segmente im Summenteil m&#252;ssen unter Nutzung der</text>
+  <text text-anchor="start" x="696.15" y="-520.18" font-family="Roboto, sans-serif" font-size="14.00">Absolutbetragfunktion &#252;bereinstimmen.</text>
+  </g>
+  <!-- 40&#45;&gt;50 -->
+  <g id="edge11" class="edge">
+  <title>40-&gt;50</title>
+  <path fill="none" stroke="#88a0d6" d="M965.01,-643.47C976.54,-624.51 991.82,-599.4 1004.39,-578.71"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="1007.33,-580.62 1009.54,-570.26 1001.35,-576.98 1007.33,-580.62"/>
+  <text text-anchor="start" x="989.65" y="-606.07" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- A05 -->
+  <g id="node13" class="node">
+  <title>A05</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M839.92,-442.59C839.92,-442.59 267.38,-442.59 267.38,-442.59 261.38,-442.59 255.38,-436.59 255.38,-430.59 255.38,-430.59 255.38,-381.31 255.38,-381.31 255.38,-375.31 261.38,-369.31 267.38,-369.31 267.38,-369.31 839.92,-369.31 839.92,-369.31 845.92,-369.31 851.92,-375.31 851.92,-381.31 851.92,-381.31 851.92,-430.59 851.92,-430.59 851.92,-436.59 845.92,-442.59 839.92,-442.59"/>
+  <text text-anchor="start" x="269.77" y="-421.65" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A05</text>
+  <text text-anchor="start" x="269.77" y="-393.65" font-family="Roboto, sans-serif" font-size="14.00">Mindestens ein Betrag der Stornorechnung ist nicht identisch mit dem Betrag der</text>
+  <text text-anchor="start" x="269.77" y="-379.65" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung.</text>
+  </g>
+  <!-- 50&#45;&gt;A05 -->
+  <g id="edge12" class="edge">
+  <title>50-&gt;A05</title>
+  <path fill="none" stroke="#88a0d6" d="M924.51,-509.86C856.63,-491.02 766.95,-466.14 692.79,-445.56"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="693.99,-442.26 683.42,-442.96 692.12,-449.01 693.99,-442.26"/>
+  <text text-anchor="start" x="804.65" y="-465.54" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- 60 -->
+  <g id="node14" class="node">
+  <title>60</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1275.68,-423.95C1275.68,-423.95 881.63,-423.95 881.63,-423.95 875.63,-423.95 869.63,-417.95 869.63,-411.95 869.63,-411.95 869.63,-399.95 869.63,-399.95 869.63,-393.95 875.63,-387.95 881.63,-387.95 881.63,-387.95 1275.68,-387.95 1275.68,-387.95 1281.68,-387.95 1287.68,-393.95 1287.68,-399.95 1287.68,-399.95 1287.68,-411.95 1287.68,-411.95 1287.68,-417.95 1281.68,-423.95 1275.68,-423.95"/>
+  <text text-anchor="start" x="884.03" y="-402.27" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">60: </text>
+  <text text-anchor="start" x="913.28" y="-402.27" font-family="Roboto, sans-serif" font-size="14.00">Ist ein zuvor nicht spezifizierter Fehler aufgetreten?</text>
+  </g>
+  <!-- 50&#45;&gt;60 -->
+  <g id="edge13" class="edge">
+  <title>50-&gt;60</title>
+  <path fill="none" stroke="#88a0d6" d="M1038.72,-509.94C1047.4,-487.55 1059.41,-456.58 1067.98,-434.46"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="1071.22,-435.79 1071.57,-425.2 1064.7,-433.26 1071.22,-435.79"/>
+  <text text-anchor="start" x="1057.65" y="-465.54" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- A99 -->
+  <g id="node15" class="node">
+  <title>A99</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M857.92,-316.06C857.92,-316.06 297.38,-316.06 297.38,-316.06 291.38,-316.06 285.38,-310.06 285.38,-304.06 285.38,-304.06 285.38,-240.78 285.38,-240.78 285.38,-234.78 291.38,-228.78 297.38,-228.78 297.38,-228.78 857.92,-228.78 857.92,-228.78 863.92,-228.78 869.92,-234.78 869.92,-240.78 869.92,-240.78 869.92,-304.06 869.92,-304.06 869.92,-310.06 863.92,-316.06 857.92,-316.06"/>
+  <text text-anchor="start" x="299.77" y="-295.12" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A99</text>
+  <text text-anchor="start" x="299.77" y="-267.12" font-family="Roboto, sans-serif" font-size="14.00">Ablehnung Sonstiges</text>
+  <text text-anchor="start" x="299.77" y="-253.12" font-family="Roboto, sans-serif" font-size="14.00">Hinweis: Das identifizierte Problem ist in der Antwort zu beschreiben/benennen.</text>
+  <text text-anchor="start" x="299.77" y="-239.12" font-family="Roboto, sans-serif" font-size="14.00">Nutzungsm&#246;glichkeit Ende: 01.04.2026 00:00 Uhr</text>
+  </g>
+  <!-- 60&#45;&gt;A99 -->
+  <g id="edge14" class="edge">
+  <title>60-&gt;A99</title>
+  <path fill="none" stroke="#88a0d6" d="M1013.92,-387.96C947.64,-370.56 841.75,-342.76 750.89,-318.9"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="751.91,-315.55 741.35,-316.4 750.13,-322.32 751.91,-315.55"/>
+  <text text-anchor="start" x="872.65" y="-339.01" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- 70 -->
+  <g id="node16" class="node">
+  <title>70</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1285.55,-290.42C1285.55,-290.42 899.75,-290.42 899.75,-290.42 893.75,-290.42 887.75,-284.42 887.75,-278.42 887.75,-278.42 887.75,-266.42 887.75,-266.42 887.75,-260.42 893.75,-254.42 899.75,-254.42 899.75,-254.42 1285.55,-254.42 1285.55,-254.42 1291.55,-254.42 1297.55,-260.42 1297.55,-266.42 1297.55,-266.42 1297.55,-278.42 1297.55,-278.42 1297.55,-284.42 1291.55,-290.42 1285.55,-290.42"/>
+  <text text-anchor="start" x="902.15" y="-268.75" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">70: </text>
+  <text text-anchor="start" x="931.4" y="-268.75" font-family="Roboto, sans-serif" font-size="14.00">Wurde der urspr&#252;nglichen Rechnung zugestimmt?</text>
+  </g>
+  <!-- 60&#45;&gt;70 -->
+  <g id="edge15" class="edge">
+  <title>60-&gt;70</title>
+  <path fill="none" stroke="#88a0d6" d="M1080.45,-388.02C1082.78,-366.12 1086.88,-327.67 1089.67,-301.39"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="1093.12,-302.1 1090.7,-291.79 1086.16,-301.36 1093.12,-302.1"/>
+  <text text-anchor="start" x="1085.65" y="-339.01" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen -->
+  <g id="node17" class="node">
+  <title>Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M893.8,-175.53C893.8,-175.53 431.5,-175.53 431.5,-175.53 425.5,-175.53 419.5,-169.53 419.5,-163.53 419.5,-163.53 419.5,-151.53 419.5,-151.53 419.5,-145.53 425.5,-139.53 431.5,-139.53 431.5,-139.53 893.8,-139.53 893.8,-139.53 899.8,-139.53 905.8,-145.53 905.8,-151.53 905.8,-151.53 905.8,-163.53 905.8,-163.53 905.8,-169.53 899.8,-175.53 893.8,-175.53"/>
+  <text text-anchor="start" x="433.9" y="-152.85" font-family="Roboto, sans-serif" font-size="14.00">Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</text>
+  </g>
+  <!-- 70&#45;&gt;Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen -->
+  <g id="edge16" class="edge">
+  <title>70-&gt;Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</title>
+  <path fill="none" stroke="#88a0d6" d="M1028.27,-254.52C950.66,-234.14 820.42,-199.95 738.15,-178.35"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="739.14,-174.99 728.58,-175.84 737.36,-181.76 739.14,-174.99"/>
+  <text text-anchor="start" x="851.65" y="-198.48" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- 80 -->
+  <g id="node18" class="node">
+  <title>80</title>
+  <path fill="#c2cee9" stroke="black" stroke-width="0" d="M1297.55,-175.53C1297.55,-175.53 935.75,-175.53 935.75,-175.53 929.75,-175.53 923.75,-169.53 923.75,-163.53 923.75,-163.53 923.75,-151.53 923.75,-151.53 923.75,-145.53 929.75,-139.53 935.75,-139.53 935.75,-139.53 1297.55,-139.53 1297.55,-139.53 1303.55,-139.53 1309.55,-145.53 1309.55,-151.53 1309.55,-151.53 1309.55,-163.53 1309.55,-163.53 1309.55,-169.53 1303.55,-175.53 1297.55,-175.53"/>
+  <text text-anchor="start" x="938.15" y="-153.85" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">80: </text>
+  <text text-anchor="start" x="967.4" y="-153.85" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung abgelehnt?</text>
+  </g>
+  <!-- 70&#45;&gt;80 -->
+  <g id="edge17" class="edge">
+  <title>70-&gt;80</title>
+  <path fill="none" stroke="#88a0d6" d="M1096.19,-254.76C1100.02,-236.75 1106.19,-207.75 1110.75,-186.29"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="1114.12,-187.25 1112.78,-176.74 1107.28,-185.79 1114.12,-187.25"/>
+  <text text-anchor="start" x="1108.65" y="-198.48" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  <!-- Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden -->
+  <g id="node19" class="node">
+  <title>Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M785.05,-77.66C785.05,-77.66 210.25,-77.66 210.25,-77.66 204.25,-77.66 198.25,-71.66 198.25,-65.66 198.25,-65.66 198.25,-20.62 198.25,-20.62 198.25,-14.62 204.25,-8.62 210.25,-8.62 210.25,-8.62 785.05,-8.62 785.05,-8.62 791.05,-8.62 797.05,-14.62 797.05,-20.62 797.05,-20.62 797.05,-65.66 797.05,-65.66 797.05,-71.66 791.05,-77.66 785.05,-77.66"/>
+  <text text-anchor="start" x="212.65" y="-55.72" font-family="Roboto, sans-serif" font-size="14.00">Hinweis:</text>
+  <text text-anchor="start" x="212.65" y="-38.47" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann</text>
+  <text text-anchor="start" x="212.65" y="-21.21" font-family="Roboto, sans-serif" font-size="14.00">ist auf die Stornorechnung keine Antwort zu senden</text>
+  </g>
+  <!-- 80&#45;&gt;Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden -->
+  <g id="edge18" class="edge">
+  <title>80-&gt;Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden</title>
+  <path fill="none" stroke="#88a0d6" d="M1023.31,-139.58C936.29,-123.78 803.74,-99.72 693.51,-79.7"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="694.19,-76.27 683.73,-77.93 692.94,-83.16 694.19,-76.27"/>
+  <text text-anchor="start" x="915.65" y="-109.23" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+  </g>
+  <!-- Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden. -->
+  <g id="node20" class="node">
+  <title>Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden.</title>
+  <path fill="#c4cac1" stroke="black" stroke-width="0" d="M1408.05,-86.28C1408.05,-86.28 827.25,-86.28 827.25,-86.28 821.25,-86.28 815.25,-80.28 815.25,-74.28 815.25,-74.28 815.25,-12 815.25,-12 815.25,-6 821.25,0 827.25,0 827.25,0 1408.05,0 1408.05,0 1414.05,0 1420.05,-6 1420.05,-12 1420.05,-12 1420.05,-74.28 1420.05,-74.28 1420.05,-80.28 1414.05,-86.28 1408.05,-86.28"/>
+  <text text-anchor="start" x="829.65" y="-64.34" font-family="Roboto, sans-serif" font-size="14.00">Hinweis:</text>
+  <text text-anchor="start" x="829.65" y="-47.09" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem</text>
+  <text text-anchor="start" x="829.65" y="-29.84" font-family="Roboto, sans-serif" font-size="14.00">Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung</text>
+  <text text-anchor="start" x="829.65" y="-12.59" font-family="Roboto, sans-serif" font-size="14.00">noch auf die Stornorechnung eine Antwort zu senden.</text>
+  </g>
+  <!-- 80&#45;&gt;Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden. -->
+  <g id="edge19" class="edge">
+  <title>80-&gt;Hinweis: 
+  Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden.</title>
+  <path fill="none" stroke="#88a0d6" d="M1116.8,-139.95C1116.9,-128.55 1117.04,-112.72 1117.18,-97.22"/>
+  <polygon fill="#88a0d6" stroke="#88a0d6" points="1120.67,-97.59 1117.26,-87.56 1113.67,-97.53 1120.67,-97.59"/>
+  <text text-anchor="start" x="1116.65" y="-109.23" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+  </g>
+  </g>
+  </svg>
+  '''
+# ---
 # name: TestEbdTableModels.test_table_to_digraph_dot_with_watermark_real_kroki_request[False][test_table_to_digraph_dot_with_watermark_real_kroki_request_background_False]
   '''
   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1052pt" height="441pt" viewBox="0.00 0.00 1051.50 441.34">

--- a/unittests/e0267.py
+++ b/unittests/e0267.py
@@ -1,5 +1,5 @@
 """
-Contains the raw data for E_0529 in the form of an EbdTable.
+Contains the raw data for E_0267 in the form of an EbdTable.
 """
 
 from rebdhuhn.models import EbdCheckResult, EbdTable, EbdTableMetaData, EbdTableRow, EbdTableSubRow

--- a/unittests/e0267.py
+++ b/unittests/e0267.py
@@ -1,0 +1,156 @@
+"""
+Contains the raw data for E_0529 in the form of an EbdTable.
+"""
+
+from rebdhuhn.models import EbdCheckResult, EbdTable, EbdTableMetaData, EbdTableRow, EbdTableSubRow
+
+e_0267 = EbdTable(
+    metadata=EbdTableMetaData(
+        ebd_code="E_0267",
+        chapter="WiM Strom",
+        section="8.27.4: AD: Abrechnung einer für den ESA erbrachten Leistung",
+        role="ESA",
+        ebd_name="E_0267_Prüfen, ob Antwort auf Stornierung erforderlich",
+        remark=None,
+    ),
+    rows=[
+        EbdTableRow(
+            step_number="10",
+            description="Ist die zu stornierende Rechnung beim Empfänger bekannt?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number=None),
+                    result_code="A01",
+                    note="Die zu stornierende Rechnung ist nicht vorhanden.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="15"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="15",
+            description="Liegt vom Rechnungssteller die in dieser Rechnung verwendete Rechnungsnummer bereits vor?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number=None),
+                    result_code="A06",
+                    note="Rechnungsnummer wurde bereits verwendet.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number="20"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="20",
+            description="Wurde die zu stornierende Rechnung bereits storniert?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number=None),
+                    result_code="A02",
+                    note="Die zu stornierende Rechnung wurde bereits storniert.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number="30"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="30",
+            description="Ist der Rechnungstyp der Stornorechnung identisch mit dem Rechnungstyp der ursprünglichen Rechnung?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number=None),
+                    result_code="A03",
+                    note="Der Rechnungstyp der Stornorechnung ist nicht identisch mit dem Rechnungstyp der ursprünglichen Rechnung.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="40"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="40",
+            description="Ist der Abrechnungszeitraum bzw. das Ausführungsdatum der Stornorechnung identisch mit dem Abrechnungszeitraum bzw. dem Ausführungsdatum der ursprünglichen Rechnung?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number=None),
+                    result_code="A04",
+                    note="Der Abrechnungszeitraum bzw. das Ausführungsdatum der Stornorechnung ist nicht identisch mit dem Abrechnungszeitraum bzw. dem Ausführungsdatum der ursprünglichen Rechnung.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="50"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="50",
+            description="Entsprechen die Beträge der Stornorechnung den Beträgen der ursprünglichen Rechnung?\n\nHinweis: Alle MOA-Segmente im Summenteil müssen unter Nutzung der Absolutbetragfunktion übereinstimmen.",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number=None),
+                    result_code="A05",
+                    note="Mindestens ein Betrag der Stornorechnung ist nicht identisch mit dem Betrag der ursprünglichen Rechnung.",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="60"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="60",
+            description="Ist ein zuvor nicht spezifizierter Fehler aufgetreten?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number=None),
+                    result_code="A99",
+                    note="Ablehnung Sonstiges\n\nHinweis: Das identifizierte Problem ist in der Antwort zu beschreiben/benennen. \nNutzungsmöglichkeit Ende: 01.04.2026 00:00 Uhr",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number="70"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="70",
+            description="Wurde der ursprünglichen Rechnung zugestimmt?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="Ende"),
+                    result_code=None,
+                    note="Stornorechnung zustimmen und im Zahlungslauf berücksichtigen",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number="80"), result_code=None, note=None
+                ),
+            ],
+            use_cases=None,
+        ),
+        EbdTableRow(
+            step_number="80",
+            description="Wurde die ursprüngliche Rechnung abgelehnt?",
+            sub_rows=[
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=True, subsequent_step_number="Ende"),
+                    result_code=None,
+                    note="Hinweis: \nWurde die ursprüngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden",
+                ),
+                EbdTableSubRow(
+                    check_result=EbdCheckResult(result=False, subsequent_step_number="Ende"),
+                    result_code=None,
+                    note="Hinweis: \nWurde die ursprüngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden.",
+                ),
+            ],
+            use_cases=None,
+        ),
+    ],
+    multi_step_instructions=None,
+)

--- a/unittests/test_files/E_0267_kroki_response.dot.svg
+++ b/unittests/test_files/E_0267_kroki_response.dot.svg
@@ -1,0 +1,359 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1428pt" height="1317pt" viewBox="0.00 0.00 1428.05 1316.77">
+<!--curl - -request POST - -url https://kroki.io/ via local kroki docker container instance hosted at http://localhost:8125/- -header 'Content-Type: application/json' - -data 'digraph D {
+    labelloc="t";
+    label=<<B><FONT POINT-SIZE="18">WiM Strom</FONT></B><BR align="left"/><BR/><B><FONT POINT-SIZE="16">8.27.4: AD: Abrechnung einer f&#252;r den ESA erbrachten Leistung</FONT></B><BR align="left"/><BR/><BR/><BR/>>;
+    ratio="compress";
+    concentrate=true;
+    pack=true;
+    rankdir=TB;
+    packmode="array";
+    size="20,20";
+    fontsize=12;
+    "Start" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#8ba2d7", label=<<B>E_0267</B><BR align="left"/><FONT>Pr&#252;fende Rolle: <B>ESA</B></FONT><BR align="center"/>>, fontname="Roboto, sans-serif"];
+    "10" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>10: </B>Ist die zu stornierende Rechnung beim Empf&#228;nger bekannt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A01" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A01</B><BR align="left"/><BR align="left"/><FONT>Die zu stornierende Rechnung ist nicht vorhanden.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "15" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>15: </B>Liegt vom Rechnungssteller die in dieser Rechnung verwendete Rechnungsnummer<BR align="left"/>bereits vor?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A06" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A06</B><BR align="left"/><BR align="left"/><FONT>Rechnungsnummer wurde bereits verwendet.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "20" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>20: </B>Wurde die zu stornierende Rechnung bereits storniert?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A02" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A02</B><BR align="left"/><BR align="left"/><FONT>Die zu stornierende Rechnung wurde bereits storniert.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "30" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>30: </B>Ist der Rechnungstyp der Stornorechnung identisch mit dem Rechnungstyp der<BR align="left"/>urspr&#252;nglichen Rechnung?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A03" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A03</B><BR align="left"/><BR align="left"/><FONT>Der Rechnungstyp der Stornorechnung ist nicht identisch mit dem Rechnungstyp<BR align="left"/>der urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "40" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>40: </B>Ist der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung<BR align="left"/>identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der<BR align="left"/>urspr&#252;nglichen Rechnung?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A04" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A04</B><BR align="left"/><BR align="left"/><FONT>Der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung ist nicht<BR align="left"/>identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der<BR align="left"/>urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "50" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>50: </B>Entsprechen die Betr&#228;ge der Stornorechnung den Betr&#228;gen der urspr&#252;nglichen Rechnung?<BR align="left"/>Hinweis: Alle MOA-Segmente im Summenteil m&#252;ssen unter Nutzung der<BR align="left"/>Absolutbetragfunktion &#252;bereinstimmen.<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A05" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A05</B><BR align="left"/><BR align="left"/><FONT>Mindestens ein Betrag der Stornorechnung ist nicht identisch mit dem Betrag der<BR align="left"/>urspr&#252;nglichen Rechnung.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "60" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>60: </B>Ist ein zuvor nicht spezifizierter Fehler aufgetreten?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "A99" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<B>A99</B><BR align="left"/><BR align="left"/><FONT>Ablehnung Sonstiges<BR align="left"/>Hinweis: Das identifizierte Problem ist in der Antwort zu beschreiben/benennen.<BR align="left"/>Nutzungsm&#246;glichkeit Ende: 01.04.2026 00:00 Uhr<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "70" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>70: </B>Wurde der urspr&#252;nglichen Rechnung zugestimmt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "80" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", label=<<B>80: </B>Wurde die urspr&#252;ngliche Rechnung abgelehnt?<BR align="left"/>>, fontname="Roboto, sans-serif"];
+    "Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Hinweis:<BR align="left"/>Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann<BR align="left"/>ist auf die Stornorechnung keine Antwort zu senden<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+    "Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden." [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c4cac1", label=<<FONT>Hinweis:<BR align="left"/>Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem<BR align="left"/>Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung<BR align="left"/>noch auf die Stornorechnung eine Antwort zu senden.<BR align="left"/></FONT>>, fontname="Roboto, sans-serif"];
+
+    "Start" -> "10" [color="#88a0d6"];
+    "10" -> "A01" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "10" -> "15" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "15" -> "A06" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "15" -> "20" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "20" -> "A02" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "20" -> "30" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "30" -> "A03" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "30" -> "40" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "40" -> "A04" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "40" -> "50" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "50" -> "A05" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "50" -> "60" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "60" -> "A99" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "60" -> "70" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "70" -> "Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "70" -> "80" [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "80" -> "Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden" [label=<<B>JA</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+    "80" -> "Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden." [label=<<B>NEIN</B>>, color="#88a0d6", fontname="Roboto, sans-serif"];
+
+    bgcolor="transparent";
+fontname="Roboto, sans-serif";
+}'--><g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 1312.77)">
+<title>D</title>
+<text text-anchor="start" x="428.03" y="-1288.67" font-family="Roboto, sans-serif" font-weight="bold" font-size="18.00">WiM Strom</text>
+<text text-anchor="start" x="428.03" y="-1260.57" font-family="Roboto, sans-serif" font-weight="bold" font-size="16.00">8.27.4: AD: Abrechnung einer f&#252;r den ESA erbrachten Leistung</text>
+<!-- Start -->
+<g id="node1" class="node">
+<title>Start</title>
+<path fill="#8ba2d7" stroke="black" stroke-width="0" d="M313.8,-1218.77C313.8,-1218.77 169.5,-1218.77 169.5,-1218.77 163.5,-1218.77 157.5,-1212.77 157.5,-1206.77 157.5,-1206.77 157.5,-1185.49 157.5,-1185.49 157.5,-1179.49 163.5,-1173.49 169.5,-1173.49 169.5,-1173.49 313.8,-1173.49 313.8,-1173.49 319.8,-1173.49 325.8,-1179.49 325.8,-1185.49 325.8,-1185.49 325.8,-1206.77 325.8,-1206.77 325.8,-1212.77 319.8,-1218.77 313.8,-1218.77"/>
+<text text-anchor="start" x="171.9" y="-1197.83" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">E_0267</text>
+<text text-anchor="start" x="171.9" y="-1183.83" font-family="Roboto, sans-serif" font-size="14.00">Pr&#252;fende Rolle: </text>
+<text text-anchor="start" x="281.4" y="-1183.83" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">ESA</text>
+</g>
+<!-- 10 -->
+<g id="node2" class="node">
+<title>10</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M467.93,-1136.49C467.93,-1136.49 15.38,-1136.49 15.38,-1136.49 9.38,-1136.49 3.38,-1130.49 3.38,-1124.49 3.38,-1124.49 3.38,-1112.49 3.38,-1112.49 3.38,-1106.49 9.38,-1100.49 15.38,-1100.49 15.38,-1100.49 467.93,-1100.49 467.93,-1100.49 473.93,-1100.49 479.93,-1106.49 479.93,-1112.49 479.93,-1112.49 479.93,-1124.49 479.93,-1124.49 479.93,-1130.49 473.93,-1136.49 467.93,-1136.49"/>
+<text text-anchor="start" x="17.78" y="-1114.82" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">10: </text>
+<text text-anchor="start" x="47.03" y="-1114.82" font-family="Roboto, sans-serif" font-size="14.00">Ist die zu stornierende Rechnung beim Empf&#228;nger bekannt?</text>
+</g>
+<!-- Start&#45;&gt;10 -->
+<g id="edge1" class="edge">
+<title>Start-&gt;10</title>
+<path fill="none" stroke="#88a0d6" d="M241.65,-1173.66C241.65,-1165.58 241.65,-1156.28 241.65,-1147.68"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="245.15,-1147.72 241.65,-1137.72 238.15,-1147.72 245.15,-1147.72"/>
+</g>
+<!-- A01 -->
+<g id="node3" class="node">
+<title>A01</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M369.3,-1047.24C369.3,-1047.24 12,-1047.24 12,-1047.24 6,-1047.24 0,-1041.24 0,-1035.24 0,-1035.24 0,-999.96 0,-999.96 0,-993.96 6,-987.96 12,-987.96 12,-987.96 369.3,-987.96 369.3,-987.96 375.3,-987.96 381.3,-993.96 381.3,-999.96 381.3,-999.96 381.3,-1035.24 381.3,-1035.24 381.3,-1041.24 375.3,-1047.24 369.3,-1047.24"/>
+<text text-anchor="start" x="14.4" y="-1026.3" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A01</text>
+<text text-anchor="start" x="14.4" y="-998.3" font-family="Roboto, sans-serif" font-size="14.00">Die zu stornierende Rechnung ist nicht vorhanden.</text>
+</g>
+<!-- 10&#45;&gt;A01 -->
+<g id="edge2" class="edge">
+<title>10-&gt;A01</title>
+<path fill="none" stroke="#88a0d6" d="M233,-1100.71C226.86,-1088.81 218.35,-1072.32 210.58,-1057.24"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="213.74,-1055.73 206.04,-1048.45 207.52,-1058.94 213.74,-1055.73"/>
+<text text-anchor="start" x="221.65" y="-1070.19" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- 15 -->
+<g id="node4" class="node">
+<title>15</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1029.8,-1040.24C1029.8,-1040.24 411.5,-1040.24 411.5,-1040.24 405.5,-1040.24 399.5,-1034.24 399.5,-1028.24 399.5,-1028.24 399.5,-1006.96 399.5,-1006.96 399.5,-1000.96 405.5,-994.96 411.5,-994.96 411.5,-994.96 1029.8,-994.96 1029.8,-994.96 1035.8,-994.96 1041.8,-1000.96 1041.8,-1006.96 1041.8,-1006.96 1041.8,-1028.24 1041.8,-1028.24 1041.8,-1034.24 1035.8,-1040.24 1029.8,-1040.24"/>
+<text text-anchor="start" x="413.9" y="-1019.3" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">15: </text>
+<text text-anchor="start" x="443.15" y="-1019.3" font-family="Roboto, sans-serif" font-size="14.00">Liegt vom Rechnungssteller die in dieser Rechnung verwendete Rechnungsnummer</text>
+<text text-anchor="start" x="413.9" y="-1005.3" font-family="Roboto, sans-serif" font-size="14.00">bereits vor?</text>
+</g>
+<!-- 10&#45;&gt;15 -->
+<g id="edge3" class="edge">
+<title>10-&gt;15</title>
+<path fill="none" stroke="#88a0d6" d="M323.99,-1100.49C401.38,-1084.51 517.97,-1060.44 604.74,-1042.53"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="605.4,-1045.97 614.49,-1040.52 603.99,-1039.11 605.4,-1045.97"/>
+<text text-anchor="start" x="480.65" y="-1070.19" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- A06 -->
+<g id="node5" class="node">
+<title>A06</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M522.05,-934.71C522.05,-934.71 199.25,-934.71 199.25,-934.71 193.25,-934.71 187.25,-928.71 187.25,-922.71 187.25,-922.71 187.25,-887.43 187.25,-887.43 187.25,-881.43 193.25,-875.43 199.25,-875.43 199.25,-875.43 522.05,-875.43 522.05,-875.43 528.05,-875.43 534.05,-881.43 534.05,-887.43 534.05,-887.43 534.05,-922.71 534.05,-922.71 534.05,-928.71 528.05,-934.71 522.05,-934.71"/>
+<text text-anchor="start" x="201.65" y="-913.77" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A06</text>
+<text text-anchor="start" x="201.65" y="-885.77" font-family="Roboto, sans-serif" font-size="14.00">Rechnungsnummer wurde bereits verwendet.</text>
+</g>
+<!-- 15&#45;&gt;A06 -->
+<g id="edge4" class="edge">
+<title>15-&gt;A06</title>
+<path fill="none" stroke="#88a0d6" d="M650.38,-995.03C597.6,-978.82 524.47,-956.37 464.88,-938.07"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="465.95,-934.74 455.37,-935.15 463.9,-941.43 465.95,-934.74"/>
+<text text-anchor="start" x="561.65" y="-957.66" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- 20 -->
+<g id="node6" class="node">
+<title>20</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M977.42,-923.07C977.42,-923.07 563.88,-923.07 563.88,-923.07 557.88,-923.07 551.88,-917.07 551.88,-911.07 551.88,-911.07 551.88,-899.07 551.88,-899.07 551.88,-893.07 557.88,-887.07 563.88,-887.07 563.88,-887.07 977.42,-887.07 977.42,-887.07 983.42,-887.07 989.42,-893.07 989.42,-899.07 989.42,-899.07 989.42,-911.07 989.42,-911.07 989.42,-917.07 983.42,-923.07 977.42,-923.07"/>
+<text text-anchor="start" x="566.27" y="-901.39" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">20: </text>
+<text text-anchor="start" x="595.52" y="-901.39" font-family="Roboto, sans-serif" font-size="14.00">Wurde die zu stornierende Rechnung bereits storniert?</text>
+</g>
+<!-- 15&#45;&gt;20 -->
+<g id="edge5" class="edge">
+<title>15-&gt;20</title>
+<path fill="none" stroke="#88a0d6" d="M730.41,-995.03C738.39,-977.38 749.73,-952.32 758.33,-933.3"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="761.48,-934.83 762.42,-924.27 755.1,-931.94 761.48,-934.83"/>
+<text text-anchor="start" x="747.65" y="-957.66" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- A02 -->
+<g id="node7" class="node">
+<title>A02</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M483.92,-822.18C483.92,-822.18 103.38,-822.18 103.38,-822.18 97.38,-822.18 91.37,-816.18 91.37,-810.18 91.37,-810.18 91.37,-774.9 91.37,-774.9 91.37,-768.9 97.37,-762.9 103.37,-762.9 103.37,-762.9 483.92,-762.9 483.92,-762.9 489.92,-762.9 495.92,-768.9 495.92,-774.9 495.92,-774.9 495.92,-810.18 495.92,-810.18 495.92,-816.18 489.92,-822.18 483.92,-822.18"/>
+<text text-anchor="start" x="105.77" y="-801.24" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A02</text>
+<text text-anchor="start" x="105.77" y="-773.24" font-family="Roboto, sans-serif" font-size="14.00">Die zu stornierende Rechnung wurde bereits storniert.</text>
+</g>
+<!-- 20&#45;&gt;A02 -->
+<g id="edge6" class="edge">
+<title>20-&gt;A02</title>
+<path fill="none" stroke="#88a0d6" d="M697.42,-887.1C625.92,-870.53 515.43,-844.93 428.09,-824.69"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="429.03,-821.32 418.49,-822.47 427.45,-828.14 429.03,-821.32"/>
+<text text-anchor="start" x="560.65" y="-845.13" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- 30 -->
+<g id="node8" class="node">
+<title>30</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1113.8,-815.18C1113.8,-815.18 525.5,-815.18 525.5,-815.18 519.5,-815.18 513.5,-809.18 513.5,-803.18 513.5,-803.18 513.5,-781.9 513.5,-781.9 513.5,-775.9 519.5,-769.9 525.5,-769.9 525.5,-769.9 1113.8,-769.9 1113.8,-769.9 1119.8,-769.9 1125.8,-775.9 1125.8,-781.9 1125.8,-781.9 1125.8,-803.18 1125.8,-803.18 1125.8,-809.18 1119.8,-815.18 1113.8,-815.18"/>
+<text text-anchor="start" x="527.9" y="-794.24" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">30: </text>
+<text text-anchor="start" x="557.15" y="-794.24" font-family="Roboto, sans-serif" font-size="14.00">Ist der Rechnungstyp der Stornorechnung identisch mit dem Rechnungstyp der</text>
+<text text-anchor="start" x="527.9" y="-780.24" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung?</text>
+</g>
+<!-- 20&#45;&gt;30 -->
+<g id="edge7" class="edge">
+<title>20-&gt;30</title>
+<path fill="none" stroke="#88a0d6" d="M778.09,-887.28C785.35,-870.9 796.59,-845.57 805.54,-825.36"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="808.65,-826.99 809.5,-816.43 802.25,-824.16 808.65,-826.99"/>
+<text text-anchor="start" x="797.65" y="-845.13" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- A03 -->
+<g id="node9" class="node">
+<title>A03</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M613.17,-709.65C613.17,-709.65 42.12,-709.65 42.12,-709.65 36.12,-709.65 30.12,-703.65 30.12,-697.65 30.12,-697.65 30.12,-648.37 30.12,-648.37 30.12,-642.37 36.12,-636.37 42.12,-636.37 42.12,-636.37 613.17,-636.37 613.17,-636.37 619.17,-636.37 625.17,-642.37 625.17,-648.37 625.17,-648.37 625.17,-697.65 625.17,-697.65 625.17,-703.65 619.17,-709.65 613.17,-709.65"/>
+<text text-anchor="start" x="44.52" y="-688.71" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A03</text>
+<text text-anchor="start" x="44.52" y="-660.71" font-family="Roboto, sans-serif" font-size="14.00">Der Rechnungstyp der Stornorechnung ist nicht identisch mit dem Rechnungstyp</text>
+<text text-anchor="start" x="44.52" y="-646.71" font-family="Roboto, sans-serif" font-size="14.00">der urspr&#252;nglichen Rechnung.</text>
+</g>
+<!-- 30&#45;&gt;A03 -->
+<g id="edge8" class="edge">
+<title>30-&gt;A03</title>
+<path fill="none" stroke="#88a0d6" d="M729.12,-769.91C661.66,-753.8 567.77,-731.37 487.75,-712.25"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="488.57,-708.85 478.03,-709.93 486.94,-715.66 488.57,-708.85"/>
+<text text-anchor="start" x="617.65" y="-732.6" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- 40 -->
+<g id="node10" class="node">
+<title>40</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1240.3,-702.65C1240.3,-702.65 655,-702.65 655,-702.65 649,-702.65 643,-696.65 643,-690.65 643,-690.65 643,-655.37 643,-655.37 643,-649.37 649,-643.37 655,-643.37 655,-643.37 1240.3,-643.37 1240.3,-643.37 1246.3,-643.37 1252.3,-649.37 1252.3,-655.37 1252.3,-655.37 1252.3,-690.65 1252.3,-690.65 1252.3,-696.65 1246.3,-702.65 1240.3,-702.65"/>
+<text text-anchor="start" x="657.4" y="-681.71" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">40: </text>
+<text text-anchor="start" x="686.65" y="-681.71" font-family="Roboto, sans-serif" font-size="14.00">Ist der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung</text>
+<text text-anchor="start" x="657.4" y="-667.71" font-family="Roboto, sans-serif" font-size="14.00">identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der</text>
+<text text-anchor="start" x="657.4" y="-653.71" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung?</text>
+</g>
+<!-- 30&#45;&gt;40 -->
+<g id="edge9" class="edge">
+<title>30-&gt;40</title>
+<path fill="none" stroke="#88a0d6" d="M843.13,-769.98C861.35,-753.25 887.02,-729.68 908.36,-710.09"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="910.48,-712.89 915.48,-703.55 905.75,-707.73 910.48,-712.89"/>
+<text text-anchor="start" x="886.65" y="-732.6" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- A04 -->
+<g id="node11" class="node">
+<title>A04</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M651.55,-583.12C651.55,-583.12 55.75,-583.12 55.75,-583.12 49.75,-583.12 43.75,-577.12 43.75,-571.12 43.75,-571.12 43.75,-507.84 43.75,-507.84 43.75,-501.84 49.75,-495.84 55.75,-495.84 55.75,-495.84 651.55,-495.84 651.55,-495.84 657.55,-495.84 663.55,-501.84 663.55,-507.84 663.55,-507.84 663.55,-571.12 663.55,-571.12 663.55,-577.12 657.55,-583.12 651.55,-583.12"/>
+<text text-anchor="start" x="58.15" y="-562.18" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A04</text>
+<text text-anchor="start" x="58.15" y="-534.18" font-family="Roboto, sans-serif" font-size="14.00">Der Abrechnungszeitraum bzw. das Ausf&#252;hrungsdatum der Stornorechnung ist nicht</text>
+<text text-anchor="start" x="58.15" y="-520.18" font-family="Roboto, sans-serif" font-size="14.00">identisch mit dem Abrechnungszeitraum bzw. dem Ausf&#252;hrungsdatum der</text>
+<text text-anchor="start" x="58.15" y="-506.18" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung.</text>
+</g>
+<!-- 40&#45;&gt;A04 -->
+<g id="edge10" class="edge">
+<title>40-&gt;A04</title>
+<path fill="none" stroke="#88a0d6" d="M818.39,-643.39C742.05,-626.48 643.71,-604.71 557.17,-585.54"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="558.13,-582.17 547.61,-583.43 556.61,-589.01 558.13,-582.17"/>
+<text text-anchor="start" x="703.65" y="-606.07" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- 50 -->
+<g id="node12" class="node">
+<title>50</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1361.55,-569.12C1361.55,-569.12 693.75,-569.12 693.75,-569.12 687.75,-569.12 681.75,-563.12 681.75,-557.12 681.75,-557.12 681.75,-521.84 681.75,-521.84 681.75,-515.84 687.75,-509.84 693.75,-509.84 693.75,-509.84 1361.55,-509.84 1361.55,-509.84 1367.55,-509.84 1373.55,-515.84 1373.55,-521.84 1373.55,-521.84 1373.55,-557.12 1373.55,-557.12 1373.55,-563.12 1367.55,-569.12 1361.55,-569.12"/>
+<text text-anchor="start" x="696.15" y="-548.18" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">50: </text>
+<text text-anchor="start" x="725.4" y="-548.18" font-family="Roboto, sans-serif" font-size="14.00">Entsprechen die Betr&#228;ge der Stornorechnung den Betr&#228;gen der urspr&#252;nglichen Rechnung?</text>
+<text text-anchor="start" x="696.15" y="-534.18" font-family="Roboto, sans-serif" font-size="14.00">Hinweis: Alle MOA-Segmente im Summenteil m&#252;ssen unter Nutzung der</text>
+<text text-anchor="start" x="696.15" y="-520.18" font-family="Roboto, sans-serif" font-size="14.00">Absolutbetragfunktion &#252;bereinstimmen.</text>
+</g>
+<!-- 40&#45;&gt;50 -->
+<g id="edge11" class="edge">
+<title>40-&gt;50</title>
+<path fill="none" stroke="#88a0d6" d="M965.01,-643.47C976.54,-624.51 991.82,-599.4 1004.39,-578.71"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="1007.33,-580.62 1009.54,-570.26 1001.35,-576.98 1007.33,-580.62"/>
+<text text-anchor="start" x="989.65" y="-606.07" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- A05 -->
+<g id="node13" class="node">
+<title>A05</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M839.92,-442.59C839.92,-442.59 267.38,-442.59 267.38,-442.59 261.38,-442.59 255.38,-436.59 255.38,-430.59 255.38,-430.59 255.38,-381.31 255.38,-381.31 255.38,-375.31 261.38,-369.31 267.38,-369.31 267.38,-369.31 839.92,-369.31 839.92,-369.31 845.92,-369.31 851.92,-375.31 851.92,-381.31 851.92,-381.31 851.92,-430.59 851.92,-430.59 851.92,-436.59 845.92,-442.59 839.92,-442.59"/>
+<text text-anchor="start" x="269.77" y="-421.65" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A05</text>
+<text text-anchor="start" x="269.77" y="-393.65" font-family="Roboto, sans-serif" font-size="14.00">Mindestens ein Betrag der Stornorechnung ist nicht identisch mit dem Betrag der</text>
+<text text-anchor="start" x="269.77" y="-379.65" font-family="Roboto, sans-serif" font-size="14.00">urspr&#252;nglichen Rechnung.</text>
+</g>
+<!-- 50&#45;&gt;A05 -->
+<g id="edge12" class="edge">
+<title>50-&gt;A05</title>
+<path fill="none" stroke="#88a0d6" d="M924.51,-509.86C856.63,-491.02 766.95,-466.14 692.79,-445.56"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="693.99,-442.26 683.42,-442.96 692.12,-449.01 693.99,-442.26"/>
+<text text-anchor="start" x="804.65" y="-465.54" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- 60 -->
+<g id="node14" class="node">
+<title>60</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1275.68,-423.95C1275.68,-423.95 881.63,-423.95 881.63,-423.95 875.63,-423.95 869.63,-417.95 869.63,-411.95 869.63,-411.95 869.63,-399.95 869.63,-399.95 869.63,-393.95 875.63,-387.95 881.63,-387.95 881.63,-387.95 1275.68,-387.95 1275.68,-387.95 1281.68,-387.95 1287.68,-393.95 1287.68,-399.95 1287.68,-399.95 1287.68,-411.95 1287.68,-411.95 1287.68,-417.95 1281.68,-423.95 1275.68,-423.95"/>
+<text text-anchor="start" x="884.03" y="-402.27" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">60: </text>
+<text text-anchor="start" x="913.28" y="-402.27" font-family="Roboto, sans-serif" font-size="14.00">Ist ein zuvor nicht spezifizierter Fehler aufgetreten?</text>
+</g>
+<!-- 50&#45;&gt;60 -->
+<g id="edge13" class="edge">
+<title>50-&gt;60</title>
+<path fill="none" stroke="#88a0d6" d="M1038.72,-509.94C1047.4,-487.55 1059.41,-456.58 1067.98,-434.46"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="1071.22,-435.79 1071.57,-425.2 1064.7,-433.26 1071.22,-435.79"/>
+<text text-anchor="start" x="1057.65" y="-465.54" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- A99 -->
+<g id="node15" class="node">
+<title>A99</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M857.92,-316.06C857.92,-316.06 297.38,-316.06 297.38,-316.06 291.38,-316.06 285.38,-310.06 285.38,-304.06 285.38,-304.06 285.38,-240.78 285.38,-240.78 285.38,-234.78 291.38,-228.78 297.38,-228.78 297.38,-228.78 857.92,-228.78 857.92,-228.78 863.92,-228.78 869.92,-234.78 869.92,-240.78 869.92,-240.78 869.92,-304.06 869.92,-304.06 869.92,-310.06 863.92,-316.06 857.92,-316.06"/>
+<text text-anchor="start" x="299.77" y="-295.12" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">A99</text>
+<text text-anchor="start" x="299.77" y="-267.12" font-family="Roboto, sans-serif" font-size="14.00">Ablehnung Sonstiges</text>
+<text text-anchor="start" x="299.77" y="-253.12" font-family="Roboto, sans-serif" font-size="14.00">Hinweis: Das identifizierte Problem ist in der Antwort zu beschreiben/benennen.</text>
+<text text-anchor="start" x="299.77" y="-239.12" font-family="Roboto, sans-serif" font-size="14.00">Nutzungsm&#246;glichkeit Ende: 01.04.2026 00:00 Uhr</text>
+</g>
+<!-- 60&#45;&gt;A99 -->
+<g id="edge14" class="edge">
+<title>60-&gt;A99</title>
+<path fill="none" stroke="#88a0d6" d="M1013.92,-387.96C947.64,-370.56 841.75,-342.76 750.89,-318.9"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="751.91,-315.55 741.35,-316.4 750.13,-322.32 751.91,-315.55"/>
+<text text-anchor="start" x="872.65" y="-339.01" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- 70 -->
+<g id="node16" class="node">
+<title>70</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1285.55,-290.42C1285.55,-290.42 899.75,-290.42 899.75,-290.42 893.75,-290.42 887.75,-284.42 887.75,-278.42 887.75,-278.42 887.75,-266.42 887.75,-266.42 887.75,-260.42 893.75,-254.42 899.75,-254.42 899.75,-254.42 1285.55,-254.42 1285.55,-254.42 1291.55,-254.42 1297.55,-260.42 1297.55,-266.42 1297.55,-266.42 1297.55,-278.42 1297.55,-278.42 1297.55,-284.42 1291.55,-290.42 1285.55,-290.42"/>
+<text text-anchor="start" x="902.15" y="-268.75" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">70: </text>
+<text text-anchor="start" x="931.4" y="-268.75" font-family="Roboto, sans-serif" font-size="14.00">Wurde der urspr&#252;nglichen Rechnung zugestimmt?</text>
+</g>
+<!-- 60&#45;&gt;70 -->
+<g id="edge15" class="edge">
+<title>60-&gt;70</title>
+<path fill="none" stroke="#88a0d6" d="M1080.45,-388.02C1082.78,-366.12 1086.88,-327.67 1089.67,-301.39"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="1093.12,-302.1 1090.7,-291.79 1086.16,-301.36 1093.12,-302.1"/>
+<text text-anchor="start" x="1085.65" y="-339.01" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen -->
+<g id="node17" class="node">
+<title>Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M893.8,-175.53C893.8,-175.53 431.5,-175.53 431.5,-175.53 425.5,-175.53 419.5,-169.53 419.5,-163.53 419.5,-163.53 419.5,-151.53 419.5,-151.53 419.5,-145.53 425.5,-139.53 431.5,-139.53 431.5,-139.53 893.8,-139.53 893.8,-139.53 899.8,-139.53 905.8,-145.53 905.8,-151.53 905.8,-151.53 905.8,-163.53 905.8,-163.53 905.8,-169.53 899.8,-175.53 893.8,-175.53"/>
+<text text-anchor="start" x="433.9" y="-152.85" font-family="Roboto, sans-serif" font-size="14.00">Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</text>
+</g>
+<!-- 70&#45;&gt;Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen -->
+<g id="edge16" class="edge">
+<title>70-&gt;Stornorechnung zustimmen und im Zahlungslauf ber&#252;cksichtigen</title>
+<path fill="none" stroke="#88a0d6" d="M1028.27,-254.52C950.66,-234.14 820.42,-199.95 738.15,-178.35"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="739.14,-174.99 728.58,-175.84 737.36,-181.76 739.14,-174.99"/>
+<text text-anchor="start" x="851.65" y="-198.48" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- 80 -->
+<g id="node18" class="node">
+<title>80</title>
+<path fill="#c2cee9" stroke="black" stroke-width="0" d="M1297.55,-175.53C1297.55,-175.53 935.75,-175.53 935.75,-175.53 929.75,-175.53 923.75,-169.53 923.75,-163.53 923.75,-163.53 923.75,-151.53 923.75,-151.53 923.75,-145.53 929.75,-139.53 935.75,-139.53 935.75,-139.53 1297.55,-139.53 1297.55,-139.53 1303.55,-139.53 1309.55,-145.53 1309.55,-151.53 1309.55,-151.53 1309.55,-163.53 1309.55,-163.53 1309.55,-169.53 1303.55,-175.53 1297.55,-175.53"/>
+<text text-anchor="start" x="938.15" y="-153.85" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">80: </text>
+<text text-anchor="start" x="967.4" y="-153.85" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung abgelehnt?</text>
+</g>
+<!-- 70&#45;&gt;80 -->
+<g id="edge17" class="edge">
+<title>70-&gt;80</title>
+<path fill="none" stroke="#88a0d6" d="M1096.19,-254.76C1100.02,-236.75 1106.19,-207.75 1110.75,-186.29"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="1114.12,-187.25 1112.78,-176.74 1107.28,-185.79 1114.12,-187.25"/>
+<text text-anchor="start" x="1108.65" y="-198.48" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+<!-- Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden -->
+<g id="node19" class="node">
+<title>Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M785.05,-77.66C785.05,-77.66 210.25,-77.66 210.25,-77.66 204.25,-77.66 198.25,-71.66 198.25,-65.66 198.25,-65.66 198.25,-20.62 198.25,-20.62 198.25,-14.62 204.25,-8.62 210.25,-8.62 210.25,-8.62 785.05,-8.62 785.05,-8.62 791.05,-8.62 797.05,-14.62 797.05,-20.62 797.05,-20.62 797.05,-65.66 797.05,-65.66 797.05,-71.66 791.05,-77.66 785.05,-77.66"/>
+<text text-anchor="start" x="212.65" y="-55.72" font-family="Roboto, sans-serif" font-size="14.00">Hinweis:</text>
+<text text-anchor="start" x="212.65" y="-38.47" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann</text>
+<text text-anchor="start" x="212.65" y="-21.21" font-family="Roboto, sans-serif" font-size="14.00">ist auf die Stornorechnung keine Antwort zu senden</text>
+</g>
+<!-- 80&#45;&gt;Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden -->
+<g id="edge18" class="edge">
+<title>80-&gt;Hinweis:
+Wurde die urspr&#252;ngliche Rechnung mit einem Nichtzahlungsavis abgelehnt, dann ist auf die Stornorechnung keine Antwort zu senden</title>
+<path fill="none" stroke="#88a0d6" d="M1023.31,-139.58C936.29,-123.78 803.74,-99.72 693.51,-79.7"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="694.19,-76.27 683.73,-77.93 692.94,-83.16 694.19,-76.27"/>
+<text text-anchor="start" x="915.65" y="-109.23" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">JA</text>
+</g>
+<!-- Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden. -->
+<g id="node20" class="node">
+<title>Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden.</title>
+<path fill="#c4cac1" stroke="black" stroke-width="0" d="M1408.05,-86.28C1408.05,-86.28 827.25,-86.28 827.25,-86.28 821.25,-86.28 815.25,-80.28 815.25,-74.28 815.25,-74.28 815.25,-12 815.25,-12 815.25,-6 821.25,0 827.25,0 827.25,0 1408.05,0 1408.05,0 1414.05,0 1420.05,-6 1420.05,-12 1420.05,-12 1420.05,-74.28 1420.05,-74.28 1420.05,-80.28 1414.05,-86.28 1408.05,-86.28"/>
+<text text-anchor="start" x="829.65" y="-64.34" font-family="Roboto, sans-serif" font-size="14.00">Hinweis:</text>
+<text text-anchor="start" x="829.65" y="-47.09" font-family="Roboto, sans-serif" font-size="14.00">Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem</text>
+<text text-anchor="start" x="829.65" y="-29.84" font-family="Roboto, sans-serif" font-size="14.00">Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung</text>
+<text text-anchor="start" x="829.65" y="-12.59" font-family="Roboto, sans-serif" font-size="14.00">noch auf die Stornorechnung eine Antwort zu senden.</text>
+</g>
+<!-- 80&#45;&gt;Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden. -->
+<g id="edge19" class="edge">
+<title>80-&gt;Hinweis:
+Wurde die urspr&#252;ngliche Rechnung noch nicht beantwortet, weder mit einem Zahlungsavis noch mit einem Nichtzahlungsavis, dann ist weder auf die Rechnung noch auf die Stornorechnung eine Antwort zu senden.</title>
+<path fill="none" stroke="#88a0d6" d="M1116.8,-139.95C1116.9,-128.55 1117.04,-112.72 1117.18,-97.22"/>
+<polygon fill="#88a0d6" stroke="#88a0d6" points="1120.67,-97.59 1117.26,-87.56 1113.67,-97.53 1120.67,-97.59"/>
+<text text-anchor="start" x="1116.65" y="-109.23" font-family="Roboto, sans-serif" font-weight="bold" font-size="14.00">NEIN</text>
+</g>
+</g>
+</svg>

--- a/unittests/test_table_to_graph.py
+++ b/unittests/test_table_to_graph.py
@@ -26,6 +26,7 @@ from rebdhuhn.models.ebd_table import EbdTable, EbdTableMetaData
 from rebdhuhn.models.errors import GraphTooComplexForPlantumlError
 from unittests.examples import table_e0003, table_e0015, table_e0025, table_e0401
 
+from .e0267 import e_0267
 from .e0487 import table_e0487
 
 
@@ -216,6 +217,11 @@ class TestEbdTableModels:
             pytest.param(
                 table_e0401,
                 "DiGraph with 23 nodes and 27 edges",
+                # todo: check if result is ok
+            ),
+            pytest.param(
+                e_0267,
+                "DiGraph with 20 nodes and 19 edges",
                 # todo: check if result is ok
             ),
         ],


### PR DESCRIPTION
Ziel ist es, folgendes Problem zu handeln:
aus E_0267:
![grafik](https://github.com/user-attachments/assets/446ae670-d16d-4b7d-a71a-a1018548e232)
bisher sah das dann so aus:
![grafik](https://github.com/user-attachments/assets/f2fcf9c1-6364-4bcc-948a-38e69d2ba1fb)

https://github.com/Hochfrequenz/rebdhuhn/pull/348 nimmt die Fälle jetzt ganz raus.

Mein Vorschlag:
![grafik](https://github.com/user-attachments/assets/688de212-6a79-49b4-bd3d-0463288dd265)

