### PR TITLE
chore: change opacity of watermark (to `#f3f3f2`≙`#ffffff` with 50% opacity over `off-white`)

### DIFF
--- a/src/rebdhuhn/hochfrequenz-logo.svg
+++ b/src/rebdhuhn/hochfrequenz-logo.svg
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Ebene_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 579.24 568.16" width="579.24" height="568.16">
-  <!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
   <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0003.dot.svg
+++ b/unittests/output/E_0003.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1440.0px" viewBox="0 0 1440.0 625.3333333333334" height="625.3333333333334px">
   <rect fill="#e7e6e5" x="0" y="0" width="1440.0" height="625.3333333333334" rx="20" ry="20"/><g>
-    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0003_with_watermark_background_is_False.dot.svg
+++ b/unittests/output/E_0003_with_watermark_background_is_False.dot.svg
@@ -1,11 +1,13 @@
 <?xml version='1.0' encoding='ASCII' standalone='yes'?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1440.0px" viewBox="0 0 1440.0 625.3333333333334" height="625.3333333333334px">
   <g>
-    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0003_with_watermark_background_is_True.dot.svg
+++ b/unittests/output/E_0003_with_watermark_background_is_True.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1440.0px" viewBox="0 0 1440.0 625.3333333333334" height="625.3333333333334px">
   <rect fill="#e7e6e5" x="0" y="0" width="1440.0" height="625.3333333333334" rx="20" ry="20"/><g>
-    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(464.988679245283, 62.533333333333324) scale(1 1) translate(0, 0) scale(0.8805031446540882 0.8805031446540882) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0015.dot.svg
+++ b/unittests/output/E_0015.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1818.6666666666667px" viewBox="0 0 1818.6666666666667 1920.0" height="1920.0px">
   <rect fill="#e7e6e5" x="0" y="0" width="1818.6666666666667" height="1920.0" rx="20" ry="20"/><g>
-    <g transform="translate(181.86666666666665, 246.44868908684953) scale(1 1) translate(0, 0) scale(2.511797067421679 2.511797067421679) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(181.86666666666665, 246.44868908684953) scale(1 1) translate(0, 0) scale(2.511797067421679 2.511797067421679) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0025.dot.svg
+++ b/unittests/output/E_0025.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1429.3333333333333px" viewBox="0 0 1429.3333333333333 925.3333333333334" height="925.3333333333334px">
   <rect fill="#e7e6e5" x="0" y="0" width="1429.3333333333333" height="925.3333333333334" rx="20" ry="20"/><g>
-    <g transform="translate(337.3151600488124, 92.53333333333332) scale(1 1) translate(0, 0) scale(1.3029193654369664 1.3029193654369664) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(337.3151600488124, 92.53333333333332) scale(1 1) translate(0, 0) scale(1.3029193654369664 1.3029193654369664) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0267.dot.svg
+++ b/unittests/output/E_0267.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1920.0px" viewBox="0 0 1920.0 1773.3333333333333" height="1773.3333333333333px">
   <rect fill="#e7e6e5" x="0" y="0" width="1920.0" height="1773.3333333333333" rx="20" ry="20"/><g>
-    <g transform="translate(236.8335680090114, 177.3333333333333) scale(1 1) translate(0, 0) scale(2.496949216183235 2.496949216183235) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(236.8335680090114, 177.3333333333333) scale(1 1) translate(0, 0) scale(2.496949216183235 2.496949216183235) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>

--- a/unittests/output/E_0401.dot.svg
+++ b/unittests/output/E_0401.dot.svg
@@ -3,11 +3,13 @@
   <g>
     <svg version="1.1" width="1920.0px" viewBox="0 0 1920.0 1661.3333333333333" height="1661.3333333333333px">
   <rect fill="#e7e6e5" x="0" y="0" width="1920.0" height="1661.3333333333333" rx="20" ry="20"/><g>
-    <g transform="translate(282.507237397916, 166.1333333333333) scale(1 1) translate(0, 0) scale(2.3392471604242937 2.3392471604242937) "><!-- note that I manually added the width and height attribute to the root node
-  https://chatgpt.com/share/678e3028-70cc-800b-a296-782714735772
-  -->
-  <defs>
-    <style>.cls-1{fill:#e7e6e588;}</style>
+    <g transform="translate(282.507237397916, 166.1333333333333) scale(1 1) translate(0, 0) scale(2.3392471604242937 2.3392471604242937) "><defs>
+    <style>.cls-1{fill:#ffffff88;}</style>
+    <!--
+    ffffff88 is white with 50% transparency; this matches the colour of the tesa strip on
+    ebd.hochfrequenz.de where it crosses the diagram SVG:
+    https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/blob/01bd43fa0f1d0333fa93596bc8b9fd1e4b285c8c/src/lib/components/features/svg-container.svelte#L54
+    -->
   </defs>
   <path class="cls-1" d="M122.44,531.2h-56.1c-11,0-19.9-9.12-19.46-20.11C57.47,243.89,278.15,29.78,547.91,29.78v56.02c0,10.98-8.69,19.89-19.66,20.39-225.51,10.31-405.8,197-405.8,425Z"/>
   <path class="cls-1" d="M273.78,531.2h-55.93c-11.23,0-20.09-9.48-19.43-20.69,10.74-183.44,163.39-329.39,349.48-329.39v56.26c0,10.71-8.27,19.62-18.96,20.35-142.35,9.77-255.17,128.69-255.17,273.46Z"/>


### PR DESCRIPTION
fixes https://github.com/Hochfrequenz/entscheidungsbaumdiagramme/issues/244