### PR TITLE
fix(config): remove corrupted permission rules from settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,10 +5,8 @@
       "Bash(git fetch:*)",
       "Bash(cat:*)",
       "WebFetch(domain:api.github.com)",
-      "Bash(.toxtestsScriptspython -m pytest unittests/test_malo_ident.py --snapshot-update)",
       "Bash(git reset:*)",
-      "Bash(gh api:*)",
-      "Bash(steps until end of graph\". Now sets end_step to start_step - 1 to create\nan empty range, ensuring _get_nodes_in_step_range returns an empty list.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n)\")"
+      "Bash(gh api:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Two entries in `.claude/settings.local.json` `permissions.allow` were invalid and have been removed:
  - A stray heredoc fragment from a past `git commit` (unbalanced parentheses), which caused Claude Code to fail parsing it with a "Mismatched parentheses" error.
  - A mangled `Bash(...)` path pattern (`.toxtestsScriptspython...`) missing separators, which could never match any real command.

## Test plan
- [x] Validated the resulting file is well-formed JSON (`jq .`)
- [x] Confirmed only the two broken entries were removed; the four valid rules are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)