### PR TITLE
fix(tests): resolve mypy --strict errors in conftest.py

### DIFF
--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from rebdhuhn import Kroki
 
 try:
-    from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
+    from testcontainers.core.container import DockerContainer
 
     TESTCONTAINERS_AVAILABLE = True
 except ImportError:
@@ -65,7 +65,7 @@ def kroki_container() -> Generator[DockerContainer, None, None]:
     # Wait for Kroki to be ready
     host = container.get_container_host_ip()
     port = container.get_exposed_port(8000)
-    wait_for_kroki(host, port)
+    wait_for_kroki(host, str(port))
 
     yield container
 


### PR DESCRIPTION
## Summary
- The `mypy` 2.1.0 → 2.3.0 bump (#564) surfaced two `--strict` errors in `unittests/conftest.py`, currently failing CI on `main`:
  - `# type: ignore[import-untyped]` on the `DockerContainer` import is now flagged as unused.
  - `get_exposed_port()` returns `int`, but `wait_for_kroki` expects `port: str` — now passed as `str(port)`.

## Test plan
- [x] CI `type_check` job passes