### PR TITLE
fix(tests): defer type annotation evaluation in conftest.py

### DIFF
--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -2,6 +2,8 @@
 Pytest fixtures for rebdhuhn tests.
 """
 
+from __future__ import annotations
+
 from typing import Generator
 
 import pytest


### PR DESCRIPTION
## Summary
- GitHub Copilot's review on #574 flagged that `DockerContainer` is referenced in fixture return-type annotations (`kroki_container`, `kroki_client`) outside the `try/except ImportError` guard around its import. Without deferred annotation evaluation, importing `conftest.py` in an environment without `testcontainers` installed would raise `NameError` at function-definition time instead of letting `TESTCONTAINERS_AVAILABLE` gate a graceful skip.
- This was masked in CI because `testcontainers` is a required `tests` extra/group, but it's still a real correctness bug.
- Fix: add `from __future__ import annotations` (PEP 563) so all annotations are deferred/lazy.
- This commit was originally pushed to #574 (`723ec31`) but landed after that PR was already merged, so it never made it into `main`. Opening it here instead.

## Test plan
- [x] `mypy --strict` still passes (annotations remain statically checkable)
- [ ] CI green