### PR TITLE
refactor: replace black, isort and pylint with ruff

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,10 +3,18 @@ name: "Formatting"
 on: [push]
 jobs:
   check:
+    # matrix values ("tool") are kept as "black"/"isort" on purpose so the required status check
+    # names "check (black)" / "check (isort)" stay stable even though ruff now runs underneath.
+    # Renaming them requires updating the branch protection required-check list in the same change.
+    name: "check (${{ matrix.tool }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tool: ["black", "isort"]
+        include:
+          - tool: "black"
+            command: "ruff format --check ."
+          - tool: "isort"
+            command: "ruff check --select I ."
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
@@ -14,7 +22,7 @@ jobs:
         with:
           python-version: 3.14
       - name: Install dependencies
-        run: uv sync --group formatting
+        run: uv sync --group linting
       - name: ${{ matrix.tool }} Code Formatter
         run: |
-          uv run ${{ matrix.tool }} . --check
+          uv run ${{ matrix.command }}

--- a/.github/workflows/pythonlint.yml
+++ b/.github/workflows/pythonlint.yml
@@ -18,7 +18,7 @@ jobs:
         run: uv sync --group ${{ matrix.linter-env }}
       - name: Run linting
         if: matrix.linter-env == 'linting'
-        run: uv run --group linting pylint rebdhuhn --ignore=_version.py
+        run: uv run --group linting ruff check src/rebdhuhn
       - name: Run type_check
         if: matrix.linter-env == 'type_check'
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,22 +7,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: ^unittests/__snapshots__/
-  - repo: https://github.com/psf/black
-    rev: 26.5.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
     hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (cython)
-        types: [cython]
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]
+      - id: ruff-check
+        args: [--fix]
+        files: ^src/rebdhuhn/
+      - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.31
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,8 @@ coverage = [
     "coverage==7.15.2",
     { include-group = "tests" },
 ]
-formatting = [
-    "black==26.5.1",
-    "isort==8.0.1"
-]
 linting = [
-    "pylint==4.0.6"
+    "ruff==0.16.0",
 ]
 spellcheck = [
     "codespell==2.4.3"
@@ -70,23 +66,36 @@ dev = [
     { include-group = "linting" },
     { include-group = "type_check" },
     { include-group = "coverage" },
-    { include-group = "formatting" },
     "pre-commit",
 ]
 
 [tool.uv]
 default-groups = []
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-target_version = ["py311", "py312", "py313", "py314"]
+target-version = "py311"
+extend-exclude = ["*.md", "src/rebdhuhn/_version.py"]
 
-[tool.isort]
-line_length = 120
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "N", "PL", "RUF"]
+ignore = [
+    "PLR0913", # too-many-arguments
+    "PLR0917", # too-many-positional-arguments
+    "PLR0912", # too-many-branches
+    "PLR0915", # too-many-statements
+    "PLR2004", # magic-value-comparison
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
+]
 
-[tool.pylint."MESSAGES CONTROL"]
-max-line-length = 120
+[tool.ruff.lint.per-file-ignores]
+# long dot/graphviz attribute strings, structurally can't be shortened
+"src/rebdhuhn/graphviz.py" = ["E501"]
+# __all__ is deliberately grouped by concept (with comments), not alphabetically sorted
+"src/rebdhuhn/__init__.py" = ["RUF022"]
+"src/rebdhuhn/models/__init__.py" = ["RUF022"]
 
 [mypy]
 truethy-bool = true

--- a/src/rebdhuhn/add_watermark.py
+++ b/src/rebdhuhn/add_watermark.py
@@ -8,7 +8,7 @@ Afterwards it gets placed into the center of the EBD diagram.
 import re
 from io import BytesIO
 from pathlib import Path
-from typing import TextIO, Tuple, Union
+from typing import TextIO
 
 from lxml import etree
 from svgutils.compose import SVG, Figure  # type: ignore[import-untyped]
@@ -61,7 +61,7 @@ def convert_dimension_to_float(dimension: str) -> float:
     return dimension_float
 
 
-def get_dimensions_of_svg(svg_as_bytes: Union[BytesIO, TextIO]) -> Tuple[float, float]:
+def get_dimensions_of_svg(svg_as_bytes: BytesIO | TextIO) -> tuple[float, float]:
     """
     Extract the dimensions of an svg image.
     :param svg_as_bytes:
@@ -200,9 +200,7 @@ def add_pruefidentifikatoren_footer(
     if len(pruefidentifikatoren) == 1:
         pruefi = pruefidentifikatoren[0]
         url = f"{_AHB_TABELLEN_BASE_URL}/{pruefi.format_version.value}/{pruefi.pruefidentifikator}"
-        link_element = etree.SubElement(
-            root, "a", attrib={"href": url, "target": "_blank"}
-        )  # pylint:disable=c-extension-no-member
+        link_element = etree.SubElement(root, "a", attrib={"href": url, "target": "_blank"})  # pylint:disable=c-extension-no-member
         text_element = etree.SubElement(  # pylint:disable=c-extension-no-member
             link_element,
             "text",
@@ -228,12 +226,8 @@ def add_pruefidentifikatoren_footer(
         prefix_tspan.text = "PI:"
         for i, pruefi in enumerate(pruefidentifikatoren):
             url = f"{_AHB_TABELLEN_BASE_URL}/{pruefi.format_version.value}/{pruefi.pruefidentifikator}"
-            link = etree.SubElement(
-                text_element, "a", attrib={"href": url, "target": "_blank"}
-            )  # pylint:disable=c-extension-no-member
-            tspan = etree.SubElement(
-                link, "tspan", attrib={"fill": "#666666", "text-decoration": "none"}
-            )  # pylint:disable=c-extension-no-member
+            link = etree.SubElement(text_element, "a", attrib={"href": url, "target": "_blank"})  # pylint:disable=c-extension-no-member
+            tspan = etree.SubElement(link, "tspan", attrib={"fill": "#666666", "text-decoration": "none"})  # pylint:disable=c-extension-no-member
             tspan.text = pruefi.pruefidentifikator
             if i < len(pruefidentifikatoren) - 1:
                 tspan.tail = ", "

--- a/src/rebdhuhn/graph_conversion.py
+++ b/src/rebdhuhn/graph_conversion.py
@@ -3,7 +3,7 @@ This module contains logic to convert EbdTable data to EbdGraph data.
 """
 
 import re
-from typing import Dict, List, Literal, Optional, overload
+from typing import Literal, overload
 
 from networkx import DiGraph, isolates  # type: ignore[import-untyped]
 
@@ -39,7 +39,7 @@ from rebdhuhn.models.errors import (
 from rebdhuhn.utils import assert_is_instance
 
 
-def _normalize_note_for_comparison(note: Optional[str]) -> Optional[str]:
+def _normalize_note_for_comparison(note: str | None) -> str | None:
     """
     Normalizes a note for comparison by stripping trailing punctuation.
 
@@ -73,7 +73,7 @@ def _is_last_step_with_no_code_but_note(sub_row: EbdTableSubRow) -> bool:
     )
 
 
-def _convert_sub_row_to_outcome_node(sub_row: EbdTableSubRow) -> Optional[OutcomeNode | TransitionalOutcomeNode]:
+def _convert_sub_row_to_outcome_node(sub_row: EbdTableSubRow) -> OutcomeNode | TransitionalOutcomeNode | None:
     """
     converts a sub_row into an outcome node (or None if not applicable)
     """
@@ -102,7 +102,7 @@ def _convert_sub_row_to_outcome_node(sub_row: EbdTableSubRow) -> Optional[Outcom
     if is_hinweis and sub_row.result_code is None and following_step:
         # We ignore Hinweise, if they are in during a decision process.
         return None
-    if sub_row.result_code is not None or sub_row.note is not None and not is_cross_reference:
+    if sub_row.result_code is not None or (sub_row.note is not None and not is_cross_reference):
         return OutcomeNode(result_code=sub_row.result_code, note=sub_row.note)
     return None
 
@@ -124,7 +124,7 @@ def _yes_no_transition_edge(
 @overload
 def _yes_no_transition_edge(decision: bool, source: DecisionNode, target: EbdGraphNode) -> EbdGraphEdge: ...
 def _yes_no_transition_edge(
-    decision: Optional[bool], source: DecisionNode | TransitionNode, target: EbdGraphNode
+    decision: bool | None, source: DecisionNode | TransitionNode, target: EbdGraphNode
 ) -> EbdGraphEdge:
     if decision is None and isinstance(source, TransitionNode):
         return TransitionEdge(source=source, target=target, note=None)
@@ -137,12 +137,12 @@ def _yes_no_transition_edge(
     raise ValueError(f"Decision must be either True or False or None, but was {decision}")
 
 
-def get_all_nodes(table: EbdTable) -> List[EbdGraphNode]:
+def get_all_nodes(table: EbdTable) -> list[EbdGraphNode]:
     """
     Returns a list with all nodes from the table.
     Nodes may both be actual EBD check outcome codes (e.g. "A55") but also points where decisions are made.
     """
-    result: List[EbdGraphNode] = [StartNode()]
+    result: list[EbdGraphNode] = [StartNode()]
     contains_ende = False
     for row in table.rows:
         decision_or_transition_node = _convert_row_to_decision_or_transition_node(row)
@@ -167,7 +167,7 @@ def get_all_nodes(table: EbdTable) -> List[EbdGraphNode]:
 
 
 def _get_key_and_node_with_lowest_step_number(ebd_table: EbdTable) -> tuple[str, EbdGraphNode]:
-    nodes: Dict[str, EbdGraphNode] = {node.get_key(): node for node in get_all_nodes(ebd_table)}
+    nodes: dict[str, EbdGraphNode] = {node.get_key(): node for node in get_all_nodes(ebd_table)}
     first_node_after_start: EbdGraphNode
     if "1" in nodes:
         first_node_after_start = nodes["1"]
@@ -186,14 +186,14 @@ def _notes_same_except_for_whitespace(note1: str | None, note2: str | None) -> b
     return note1 is None and note2 is None
 
 
-def get_all_edges(table: EbdTable) -> List[EbdGraphEdge]:
+def get_all_edges(table: EbdTable) -> list[EbdGraphEdge]:
     """
     Returns a list with all edges from the given table.
     Edges connect decisions with outcomes or subsequent steps.
     """
-    nodes: Dict[str, EbdGraphNode] = {node.get_key(): node for node in get_all_nodes(table)}
+    nodes: dict[str, EbdGraphNode] = {node.get_key(): node for node in get_all_nodes(table)}
     first_node_after_start = _get_key_and_node_with_lowest_step_number(table)[1]
-    result: List[EbdGraphEdge] = [EbdGraphEdge(source=nodes["Start"], target=first_node_after_start, note=None)]
+    result: list[EbdGraphEdge] = [EbdGraphEdge(source=nodes["Start"], target=first_node_after_start, note=None)]
 
     for row in table.rows:
         row_node = _convert_row_to_decision_or_transition_node(row)
@@ -223,9 +223,7 @@ def get_all_edges(table: EbdTable) -> List[EbdGraphEdge]:
                     )
                 )
             else:
-                outcome_node: Optional[OutcomeNode | TransitionalOutcomeNode] = _convert_sub_row_to_outcome_node(
-                    sub_row
-                )
+                outcome_node: OutcomeNode | TransitionalOutcomeNode | None = _convert_sub_row_to_outcome_node(sub_row)
 
                 if isinstance(outcome_node, TransitionalOutcomeNode):
                     result.append(

--- a/src/rebdhuhn/graph_utils.py
+++ b/src/rebdhuhn/graph_utils.py
@@ -40,7 +40,7 @@ def _mark_last_common_ancestors(graph: DiGraph) -> None:
     """
     if len(graph.nodes) > 90:
         raise GraphTooComplexForPlantumlError(
-            message=f"Graph is too large to determine the last common ancestors.Number of Nodes: {len(graph.nodes)}"
+            message=f"Graph is too large to determine the last common ancestors. Number of Nodes: {len(graph.nodes)}"
         )
     for node in graph:
         in_degree: int = graph.in_degree(node)

--- a/src/rebdhuhn/graph_utils.py
+++ b/src/rebdhuhn/graph_utils.py
@@ -4,8 +4,6 @@ Some of these functions may store some information in the "attribute dictionarie
 (for later use in the conversion logic).
 """
 
-from typing import List, Tuple
-
 from networkx import DiGraph, all_simple_paths  # type: ignore[import-untyped]
 
 from rebdhuhn.models import ToNoEdge, ToYesEdge
@@ -15,7 +13,7 @@ COMMON_ANCESTOR_FIELD = "common_ancestor_for_node"
 # Defines the label to annotate the last common ancestor node with the information to which node
 
 
-def _find_last_common_ancestor(paths: List[List[str]]) -> str:
+def _find_last_common_ancestor(paths: list[list[str]]) -> str:
     """
     This function calculates the last common ancestor node for the defined paths (these paths should be all paths
     between two nodes in the graph).
@@ -42,7 +40,7 @@ def _mark_last_common_ancestors(graph: DiGraph) -> None:
     """
     if len(graph.nodes) > 90:
         raise GraphTooComplexForPlantumlError(
-            message=f"Graph is too large to determine the last common ancestors." f"Number of Nodes: {len(graph.nodes)}"
+            message=f"Graph is too large to determine the last common ancestors.Number of Nodes: {len(graph.nodes)}"
         )
     for node in graph:
         in_degree: int = graph.in_degree(node)
@@ -65,14 +63,14 @@ def _mark_last_common_ancestors(graph: DiGraph) -> None:
             graph.nodes[common_ancestor][COMMON_ANCESTOR_FIELD].append(node)
 
 
-def _get_yes_no_edges(graph: DiGraph, node: str) -> Tuple[ToYesEdge, ToNoEdge]:
+def _get_yes_no_edges(graph: DiGraph, node: str) -> tuple[ToYesEdge, ToNoEdge]:
     """
     A shorthand to get the yes-edge and the no-edge of a decision node.
     """
     yes_edge: ToYesEdge
     no_edge: ToNoEdge
-    for edge in graph[node].values():
-        edge = edge["edge"]
+    for edge_data in graph[node].values():
+        edge = edge_data["edge"]
         match edge:
             case ToYesEdge():
                 assert "yes_edge" not in locals(), f"Multiple yes edges found for node {node}"
@@ -81,7 +79,7 @@ def _get_yes_no_edges(graph: DiGraph, node: str) -> Tuple[ToYesEdge, ToNoEdge]:
                 assert "no_edge" not in locals(), f"Multiple no edges found for node {node}"
                 no_edge = edge
             case _:
-                assert False, f"Unknown edge type: {edge}"
+                raise AssertionError(f"Unknown edge type: {edge}")
     assert "yes_edge" in locals(), f"No yes edge found for node {node}"
     assert "no_edge" in locals(), f"No no edge found for node {node}"
     return yes_edge, no_edge

--- a/src/rebdhuhn/graphviz.py
+++ b/src/rebdhuhn/graphviz.py
@@ -144,9 +144,7 @@ def _convert_outcome_node_to_dot(
     if not is_outcome_without_code:
         formatted_label += f'<B>{outcome_node.result_code}</B><BR align="left"/><BR align="left"/>'
     if outcome_node.note:
-        formatted_label += (
-            f"<FONT>" f'{_format_label(outcome_node.note, ebd_link_template)}<BR align="left"/>' f"</FONT>"
-        )
+        formatted_label += f'<FONT>{_format_label(outcome_node.note, ebd_link_template)}<BR align="left"/></FONT>'
 
     # Build node attributes
     attrs = [
@@ -178,8 +176,8 @@ def _convert_decision_node_to_dot(ebd_graph: EbdGraph, node: str, indent: str) -
     Convert a DecisionNode to dot code
     """
     formatted_label = (
-        f'<B>{ebd_graph.graph.nodes[node]["node"].step_number}: </B>'
-        f'{_format_label(ebd_graph.graph.nodes[node]["node"].question)}'
+        f"<B>{ebd_graph.graph.nodes[node]['node'].step_number}: </B>"
+        f"{_format_label(ebd_graph.graph.nodes[node]['node'].question)}"
         f'<BR align="left"/>'
     )
     return (
@@ -193,14 +191,12 @@ def _convert_transition_node_to_dot(ebd_graph: EbdGraph, node: str, indent: str)
     Convert a TransitionNode to dot code
     """
     formatted_label = (
-        f'<B>{ebd_graph.graph.nodes[node]["node"].step_number}: </B>'
-        f'{_format_label(ebd_graph.graph.nodes[node]["node"].question)}'
+        f"<B>{ebd_graph.graph.nodes[node]['node'].step_number}: </B>"
+        f"{_format_label(ebd_graph.graph.nodes[node]['node'].question)}"
         f'<BR align="left"/>'
     )
     if ebd_graph.graph.nodes[node]["node"].note:
-        formatted_label += (
-            f"<FONT>" f'{_format_label(ebd_graph.graph.nodes[node]["node"].note)}<BR align="left"/>' f"</FONT>"
-        )
+        formatted_label += f'<FONT>{_format_label(ebd_graph.graph.nodes[node]["node"].note)}<BR align="left"/></FONT>'
     return (
         f'{indent}"{node}" [margin="0.2,0.12", shape=box, style="filled,rounded", penwidth=0.0, fillcolor="#c2cee9", '
         f'label=<{formatted_label}>, fontname="Roboto, sans-serif"];'

--- a/src/rebdhuhn/models/ebd_graph.py
+++ b/src/rebdhuhn/models/ebd_graph.py
@@ -4,7 +4,7 @@ contains the graph side of things
 
 import re
 from abc import ABC, abstractmethod
-from typing import Annotated, List, Optional, Union
+from typing import Annotated
 
 from networkx import DiGraph  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -112,18 +112,18 @@ class EbdGraphMetaData(BaseModel):
     """
     e.g. 'BIKO' for "Prüfende Rolle: 'BIKO'"
     """
-    remark: Optional[str] = None
+    remark: str | None = None
     """
     remark for empty ebd sections, e.g. 'Derzeit ist für diese Entscheidung kein Entscheidungsbaum notwendig,
     da keine Antwort gegeben wird und ausschließlich die Liste versandt wird.'
     """
 
-    release_information: Optional[EbdDocumentReleaseInformation] = None
+    release_information: EbdDocumentReleaseInformation | None = None
     """
     metadata of the entire EBD document (not the single EBD table)
     """
 
-    pruefidentifikatoren: Optional[list[EbdPruefidentifikator]] = None
+    pruefidentifikatoren: list[EbdPruefidentifikator] | None = None
     """
     Pruefidentifikatoren associated with this EBD, paired with their format version
     for link generation to ahb-tabellen.hochfrequenz.de.
@@ -180,12 +180,12 @@ class OutcomeNode(EbdGraphNode):  # networkx requirement: nodes are hashable (fr
     An outcome node is a leaf of the Entscheidungsbaum tree. It has no subsequent steps.
     """
 
-    result_code: Optional[GraphResultCode] = None
+    result_code: GraphResultCode | None = None
     """
     The outcome of the decision tree check; e.g. 'A55'
     """
 
-    note: Optional[str] = None
+    note: str | None = None
     """
     An optional note for this outcome; e.g. 'Cluster:Ablehnung\nFristüberschreitung'
     """
@@ -258,7 +258,7 @@ class TransitionalOutcomeNode(EbdGraphNode):  # networkx requirement: nodes are 
     The number of the subsequent step, e.g. '2' or '110'. Needed for key generation.
     """
 
-    note: Optional[str] = None
+    note: str | None = None
     """
     An optional note for this outcome; e.g. 'Cluster:Ablehnung\nFristüberschreitung'
     """
@@ -283,7 +283,7 @@ class TransitionNode(EbdGraphNode):
     """
     the questions which is asked at this node in the tree
     """
-    note: Optional[str] = None
+    note: str | None = None
     """
     An optional note that explains the purpose, e.g.
     'Aufnahme von 0..n Treffern in die neue Trefferliste auf Basis von drei Kriterien'
@@ -308,7 +308,7 @@ class EbdGraphEdge(BaseModel):
     """
     the destination/target of the edge
     """
-    note: Optional[str] = None
+    note: str | None = None
     """
     An optional note for this edge.
     If the note doesn't refer to a OutcomeNode - e.g. 'Cluster:Ablehnung\nFristüberschreitung' -
@@ -354,7 +354,7 @@ class TransitionalOutcomeEdge(EbdGraphEdge):
     an edge that connects a transitional outcome node from the last or to the respective next step
     """
 
-    source: Union[DecisionNode, TransitionalOutcomeNode]
+    source: DecisionNode | TransitionalOutcomeNode
     """
     ths source which refers to the next step
     """
@@ -378,7 +378,7 @@ class EbdGraph(BaseModel):
     """
 
     # pylint: disable=duplicate-code
-    multi_step_instructions: Optional[List[MultiStepInstruction]] = None
+    multi_step_instructions: list[MultiStepInstruction] | None = None
     """
     If this is not None, it means that from some point in the EBD onwards, the user is thought to obey additional
     instructions. There might be more than one of these instructions in one EBD table.

--- a/src/rebdhuhn/models/ebd_table.py
+++ b/src/rebdhuhn/models/ebd_table.py
@@ -7,7 +7,7 @@ An EbdTable is the EDI@Energy raw representation of an "Entscheidungsbaum".
 import re
 from datetime import date
 from importlib.metadata import PackageNotFoundError, version
-from typing import Annotated, List, Optional
+from typing import Annotated
 
 from efoli import EdifactFormatVersion
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -85,7 +85,7 @@ class EbdDocumentReleaseInformation(BaseModel):
     the version of the .docx document/file on which this EBD table is based.
     E.g. '4.0b', because (proper) semantic versioning is for loosers ;)
     """
-    release_date: Optional[date] = None
+    release_date: date | None = None
     """
     date on which the .docx document/file was released.
     This corresponds to the 'Stand' field in the EDI@Energy document title page, e.g. '2025-06-23'.
@@ -94,7 +94,7 @@ class EbdDocumentReleaseInformation(BaseModel):
     """
     # https://imgflip.com/i/a2saev
 
-    original_release_date: Optional[date] = None
+    original_release_date: date | None = None
     """
     date on which the EBD was originally released; It's called 'Ursprüngliches Publikationsdatum' on the EBD document
     title page. E.g. '2024-10-01'.
@@ -102,13 +102,13 @@ class EbdDocumentReleaseInformation(BaseModel):
     # I think that one could validate that if a `release_date` is set, then the `original_release_date` must be set and
     # before it. But we don't add this validation yet, because we all know the data integrity is... to be improved.
 
-    rebdhuhn_version: Optional[SemanticVersion] = Field(default_factory=lambda: _get_package_version("rebdhuhn"))
+    rebdhuhn_version: SemanticVersion | None = Field(default_factory=lambda: _get_package_version("rebdhuhn"))
     """
     Version of rebdhuhn used to process this EBD, e.g. 'v0.18.2'.
     Automatically populated from the installed package version.
     """
 
-    ebdamame_version: Optional[SemanticVersion] = Field(default_factory=lambda: _get_package_version("ebdamame"))
+    ebdamame_version: SemanticVersion | None = Field(default_factory=lambda: _get_package_version("ebdamame"))
     """
     Version of ebdamame used to parse this EBD, e.g. 'v0.5.0'.
     Automatically populated from the installed package version.
@@ -146,30 +146,30 @@ class EbdTableMetaData(BaseModel):
     EBD name from the EDI@Energy Document
     e.g. 'E_0003_Bestellung der Aggregationsebene RZ prüfen'
     """
-    remark: Optional[str] = None
+    remark: str | None = None
     """
     remark for empty ebd sections, e.g. 'Derzeit ist für diese Entscheidung kein Entscheidungsbaum notwendig,
     da keine Antwort gegeben wird und ausschließlich die Liste versandt wird.'
     """
 
-    release_information: Optional[EbdDocumentReleaseInformation] = None
+    release_information: EbdDocumentReleaseInformation | None = None
     """
     metadata of the entire EBD document (not the single EBD table)
     """
 
-    note: Optional[str] = None
+    note: str | None = None
     """
     Optional note about the source of this EBD table.
     E.g. 'Diese Tabelle stammt aus dem ebd.docx EBD_4.0b_20250606_20250930_20250430'
     """
 
-    link: Optional[str] = None
+    link: str | None = None
     """
     Optional link to the source document.
     E.g. 'https://github.com/Hochfrequenz/edi_energy_mirror/blob/.../EBD_4.0b_20250606_....docx'
     """
 
-    pruefidentifikatoren: Optional[list[EbdPruefidentifikator]] = None
+    pruefidentifikatoren: list[EbdPruefidentifikator] | None = None
     """
     Pruefidentifikatoren associated with this EBD, paired with their format version
     for link generation to ahb-tabellen.hochfrequenz.de.
@@ -190,12 +190,12 @@ class EbdCheckResult(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    result: Optional[bool] = None
+    result: bool | None = None
     """
     Either "ja"=True or "nein"=False
     """
 
-    subsequent_step_number: Optional[SubsequentStepNumber] = None
+    subsequent_step_number: SubsequentStepNumber | None = None
     """
     Key of the following/subsequent step, e.g. '2', or '6*' or None, if there is no follow up step
     """
@@ -206,7 +206,7 @@ class EbdCheckResult(BaseModel):
         if self.result is None and self.subsequent_step_number is None:
             raise ValueError(
                 # pylint:disable=line-too-long
-                "If the result is not boolean (meaning neither 'ja' nor 'nein' but null), the subsequent step has to be set"
+                "If the result is not boolean (meaning neither 'ja' nor 'nein' but null), the subsequent step has to be set"  # noqa: E501
             )
         return self
 
@@ -224,13 +224,13 @@ class EbdTableSubRow(BaseModel):
     """
     The column 'Prüfergebnis'
     """
-    result_code: Optional[ResultCode] = None
+    result_code: ResultCode | None = None
     """
     The outcome if no subsequent step was defined in the CheckResult.
     The German column header is 'Code'.
     """
 
-    note: Optional[str] = None
+    note: str | None = None
     """
     An optional note for this outcome.
     E.g. 'Cluster:Ablehnung\nFristüberschreitung'
@@ -269,11 +269,11 @@ class EbdTableRow(BaseModel):
     E.g. 'Erfolgt die Aktivierung nach Ablauf der Clearingfrist für die KBKA?'
     The German column header is 'Prüfschritt'.
     """
-    sub_rows: List[EbdTableSubRow]
+    sub_rows: list[EbdTableSubRow]
     """
     One table row splits into multiple sub rows: one sub row for each check result (ja/nein)
     """
-    use_cases: Optional[List[str]] = None
+    use_cases: list[str] | None = None
     """
     If certain rows of the EBD table are only relevant for specific use cases/scenarios, you can denote them here.
     E.g. E_0462 step_number 15 may only be applied for use_cases=["Einzug"].
@@ -365,13 +365,13 @@ class EbdTable(BaseModel):
     """
     meta data about the table.
     """
-    rows: List[EbdTableRow]
+    rows: list[EbdTableRow]
     """
     rows are the body of the table;
     might have 0 rows, if the EBD exists but is just a paragraph of text, no real table
     """
     # pylint: disable=duplicate-code
-    multi_step_instructions: Optional[List[MultiStepInstruction]] = None
+    multi_step_instructions: list[MultiStepInstruction] | None = None
     """
     If this is not None, it means that from some point in the EBD onwards, the user is thought to obey additional
     instructions. There might be more than one of these instructions in one EBD table.

--- a/src/rebdhuhn/models/errors/__init__.py
+++ b/src/rebdhuhn/models/errors/__init__.py
@@ -3,8 +3,6 @@ Specific error classes for errors that may occur in the data.
 Using these exceptions allows to catch/filter more fine-grained.
 """
 
-from typing import Optional
-
 from rebdhuhn.models import DecisionNode, EbdTableRow, EbdTableSubRow, OutcomeNode
 
 
@@ -96,7 +94,7 @@ class GraphTooComplexForPlantumlError(PlantumlConversionError):
     def __init__(
         self,
         # pylint:disable=line-too-long
-        message: str = "Plantuml conversion doesn't support multiple nodes for an ancestor node. The graph is too complex.",
+        message: str = "Plantuml conversion doesn't support multiple nodes for an ancestor node. The graph is too complex.",  # noqa: E501
     ) -> None:
         self.message = message
         super().__init__(self.message)
@@ -136,7 +134,7 @@ class EbdCrossReferenceNotSupportedError(GraphConversionError, NotImplementedErr
     """
 
     def __init__(self, decision_node: DecisionNode, row: EbdTableRow):
-        cross_reference: Optional[str] = None
+        cross_reference: str | None = None
         for sub_row in row.sub_rows:
             if sub_row.note is not None and sub_row.note.startswith("EBD "):
                 cross_reference = sub_row.note.split(" ")[1]

--- a/src/rebdhuhn/plantuml.py
+++ b/src/rebdhuhn/plantuml.py
@@ -64,7 +64,7 @@ def _convert_outcome_node_to_plantuml(graph: DiGraph, node: str, indent: str) ->
     result = f"{indent}:{outcome_node.result_code};\n"
     if outcome_node.note is not None:
         note = outcome_node.note.replace("\n", f"\n{indent}{ADD_INDENT}")
-        result += f"{indent}note left\n" f"{indent}{ADD_INDENT}{_escape_for_plantuml(note)}\n" f"{indent}endnote\n"
+        result += f"{indent}note left\n{indent}{ADD_INDENT}{_escape_for_plantuml(note)}\n{indent}endnote\n"
     return f"{result}{indent}kill;\n"
 
 
@@ -81,7 +81,7 @@ def _convert_transitional_outcome_node_to_plantuml(graph: DiGraph, node: str, in
     result = f"{indent}:{trans_outcome_node.result_code};\n"
     if trans_outcome_node.note is not None:
         note = trans_outcome_node.note.replace("\n", f"\n{indent}{ADD_INDENT}")
-        result += f"{indent}note left\n" f"{indent}{ADD_INDENT}{_escape_for_plantuml(note)}\n" f"{indent}endnote\n"
+        result += f"{indent}note left\n{indent}{ADD_INDENT}{_escape_for_plantuml(note)}\n{indent}endnote\n"
 
     # Get the subsequent node and convert it (unless it has indegree > 1,
     # in which case it will be rendered at its common ancestor)
@@ -238,7 +238,7 @@ def convert_graph_to_plantuml(graph: EbdGraph) -> str:
     if "1" in nx_graph["Start"]:
         key_of_first_node = "1"
     else:
-        key_of_first_node = list(nx_graph["Start"].keys())[0]
+        key_of_first_node = next(iter(nx_graph["Start"].keys()))
     plantuml_code += _convert_node_to_plantuml(nx_graph, key_of_first_node, "")
 
     return plantuml_code + "\n@enduml\n"

--- a/unittests/test_add_watermark.py
+++ b/unittests/test_add_watermark.py
@@ -34,9 +34,9 @@ class TestAddReleaseInfoFooter:
 
         # Find all <a> elements
         a_elements = root.findall(".//{http://www.w3.org/2000/svg}a") + root.findall(".//a")
-        assert any(
-            elem.attrib.get("href") == "https://ebd.hochfrequenz.de" for elem in a_elements
-        ), "Footer must contain a hyperlink to https://ebd.hochfrequenz.de"
+        assert any(elem.attrib.get("href") == "https://ebd.hochfrequenz.de" for elem in a_elements), (
+            "Footer must contain a hyperlink to https://ebd.hochfrequenz.de"
+        )
 
     def test_footer_link_text_is_not_underlined(self) -> None:
         """The footer text must not have an underline (text-decoration: none)."""
@@ -49,9 +49,9 @@ class TestAddReleaseInfoFooter:
         root = etree.fromstring(svg_result.encode("utf-8"))
 
         text_elements = root.findall(".//{http://www.w3.org/2000/svg}text") + root.findall(".//text")
-        assert any(
-            elem.attrib.get("text-decoration") == "none" for elem in text_elements
-        ), "Footer text must have text-decoration='none' to avoid an ugly underline"
+        assert any(elem.attrib.get("text-decoration") == "none" for elem in text_elements), (
+            "Footer text must have text-decoration='none' to avoid an ugly underline"
+        )
 
     def test_footer_returns_unchanged_svg_when_version_is_missing(self) -> None:
         """If the release info has no version, the SVG should be returned unchanged."""

--- a/unittests/test_e0259_transitional_outcome.py
+++ b/unittests/test_e0259_transitional_outcome.py
@@ -38,9 +38,9 @@ class TestE0259TransitionalOutcome:
 
         assert len(transitional_nodes) > 0, "Expected E_0259 to have TransitionalOutcomeNode nodes"
         # E_0259 has 12 TransitionalOutcomeNode nodes
-        assert (
-            len(transitional_nodes) >= 10
-        ), f"Expected at least 10 TransitionalOutcomeNodes, got {len(transitional_nodes)}"
+        assert len(transitional_nodes) >= 10, (
+            f"Expected at least 10 TransitionalOutcomeNodes, got {len(transitional_nodes)}"
+        )
 
     def test_e0259_dot_conversion_succeeds(self, e0259_table: EbdTable) -> None:
         """Verify that E_0259 can be converted to DOT format."""
@@ -97,6 +97,6 @@ class TestE0259TransitionalOutcome:
 
         # PlantUML size should be reasonable (< 100KB for a 60-node graph)
         assert len(plantuml_code) < 100_000, (
-            f"PlantUML code is {len(plantuml_code):,} chars ({len(plantuml_code)/1024:.1f} KB). "
+            f"PlantUML code is {len(plantuml_code):,} chars ({len(plantuml_code) / 1024:.1f} KB). "
             "This suggests exponential duplication."
         )

--- a/unittests/test_table_to_graph.py
+++ b/unittests/test_table_to_graph.py
@@ -59,9 +59,7 @@ class InterceptedKrokiClient(Kroki):
             "--url https://kroki.io/ via local kroki docker container instance hosted at http://localhost:8125/"
             "--header 'Content-Type: application/json' "
             f"--data '{args[0]}'"
-        ).replace(
-            "--", "- -"
-        )  # replace double hyphen for xml compatability
+        ).replace("--", "- -")  # replace double hyphen for xml compatability
         result_tree.insert(0, etree.Comment(my_comment))
         self.intercepted_kroki_response_with_xml_comment = etree.tostring(result_tree).decode("utf-8")
         return result
@@ -826,6 +824,6 @@ class TestEbdReferencesPropagation:
         for node_key in graph.graph.nodes:
             node = graph.graph.nodes[node_key]["node"]
             if isinstance(node, OutcomeNode):
-                assert not any(
-                    node.ebd_references
-                ), f"Expected empty list for {node.get_key()}, got {node.ebd_references}"
+                assert not any(node.ebd_references), (
+                    f"Expected empty list for {node.get_key()}, got {node.ebd_references}"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -58,52 +58,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astroid"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -294,18 +248,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
-]
-
-[[package]]
 name = "codespell"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -464,15 +406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -541,15 +474,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -736,15 +660,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/99/da/1a3a3e5d159b249fc2970d73437496b908de8e4716a089c69591b4ffa6fd/lxml-stubs-0.5.1.tar.gz", hash = "sha256:e0ec2aa1ce92d91278b719091ce4515c12adc1d564359dfaf81efa7d4feab79d", size = 14778, upload-time = "2024-01-10T09:37:46.521Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/c9/e0f8e4e6e8a69e5959b06499582dca6349db6769cc7fdfb8a02a7c75a9ae/lxml_stubs-0.5.1-py3-none-any.whl", hash = "sha256:1f689e5dbc4b9247cb09ae820c7d34daeb1fdbd1db06123814b856dae7787272", size = 13584, upload-time = "2024-01-10T09:37:44.931Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1014,24 +929,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pylint"
-version = "4.0.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1067,40 +964,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -1210,26 +1073,20 @@ coverage = [
     { name = "testcontainers" },
 ]
 dev = [
-    { name = "black" },
     { name = "coverage" },
-    { name = "isort" },
     { name = "lxml-stubs" },
     { name = "mypy" },
     { name = "pre-commit" },
-    { name = "pylint" },
     { name = "pytest" },
     { name = "requests-mock" },
+    { name = "ruff" },
     { name = "syrupy" },
     { name = "testcontainers" },
     { name = "types-docker" },
     { name = "types-requests" },
 ]
-formatting = [
-    { name = "black" },
-    { name = "isort" },
-]
 linting = [
-    { name = "pylint" },
+    { name = "ruff" },
 ]
 spellcheck = [
     { name = "codespell" },
@@ -1270,25 +1127,19 @@ coverage = [
     { name = "testcontainers", specifier = ">=4.0.0" },
 ]
 dev = [
-    { name = "black", specifier = "==26.5.1" },
     { name = "coverage", specifier = "==7.15.2" },
-    { name = "isort", specifier = "==8.0.1" },
     { name = "lxml-stubs", specifier = "==0.5.1" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pre-commit" },
-    { name = "pylint", specifier = "==4.0.6" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "requests-mock" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "syrupy", specifier = "==2026.4.6.124150327040" },
     { name = "testcontainers", specifier = ">=4.0.0" },
     { name = "types-docker", specifier = ">=7.0.0" },
     { name = "types-requests", specifier = "==2.33.0.20260712" },
 ]
-formatting = [
-    { name = "black", specifier = "==26.5.1" },
-    { name = "isort", specifier = "==8.0.1" },
-]
-linting = [{ name = "pylint", specifier = "==4.0.6" }]
+linting = [{ name = "ruff", specifier = "==0.16.0" }]
 spellcheck = [{ name = "codespell", specifier = "==2.4.3" }]
 tests = [
     { name = "pytest", specifier = "==9.1.1" },
@@ -1335,6 +1186,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
 name = "svgutils"
 version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1372,15 +1248,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/13/2cc466bddf26d0085f30a2b2bd56b7f8708b54a54db833eec97c5c69129b/testcontainers-4.15.0.tar.gz", hash = "sha256:085cde086337632e19002719460b7b80bbab2bdd51bb3ea04f77d0de96504706", size = 95340, upload-time = "2026-07-24T23:08:01.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/7e/424aac8b355597835deb333e757a0e94b5ccf38ad00f07fe6ed1f4e17c88/testcontainers-4.15.0-py3-none-any.whl", hash = "sha256:8796c14e76604031ad39cf0ed3b8e9806283a1fbf5270965c2b1c594caa31b74", size = 160771, upload-time = "2026-07-24T23:08:00.13Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replaces `black`, `isort`, and `pylint` with `ruff` (0.16.0) for both formatting and linting.
- Merges the `formatting`/`linting` dependency groups into a single `linting` group.
- Translates `[tool.black]`/`[tool.isort]`/`[tool.pylint."MESSAGES CONTROL"]` into `[tool.ruff]`/`[tool.ruff.lint]`, selecting `E, W, F, I, UP, B, N, PL, RUF` with a small ignore list for rule categories pylint's default config never enforced (`PLR0913/PLR0917/PLR0912/PLR0915`, `PLR2004`) and ambiguous-unicode-character rules that fire on legitimate German domain text (`RUF001/002/003`).
- `too-few-public-methods`/`too-many-instance-attributes` pylint disables in the source have no ruff equivalent (same class of gap as pylint's type-inference checks like `no-member`) — left in place as harmless dead comments.
- `.pre-commit-config.yaml`: swaps `psf/black` + `pycqa/isort` for `astral-sh/ruff-pre-commit` (`v0.16.0`).
- CI: `pythonlint.yml`'s `linting` matrix leg now runs `ruff check src/rebdhuhn` (same path scope pylint used, excluding `_version.py` via `extend-exclude`). `formatting.yml` keeps its `tool: ["black", "isort"]` matrix values (now paired with a real `ruff format --check .` / `ruff check --select I .` command each, via `matrix.include`) and an explicit job `name:` so the required status checks `check (black)`/`check (isort)` keep reporting under their existing names.
- Fixed the small number of real findings ruff surfaced within `src/rebdhuhn`: a loop-variable shadowed by reassignment (`graph_utils.py`, `PLW2901`), a now-genuinely-unused `Optional` import left over after `UP045`/`UP007` modernized type hints, and reformatted 8 files to match `ruff format` (real formatting differences vs. black, e.g. adjacent string-literal joining, assert-message wrapping).

## Test plan
- [x] `uv run --group linting ruff check src/rebdhuhn` — clean (pylint's old scope)
- [x] `uv run --group linting ruff check --select I .` — clean (isort's old scope, whole repo)
- [x] `uv run --group linting ruff format --check .` — clean, 39 files (black's old scope, whole repo); confirmed no `.md` files touched
- [ ] Full `mypy --strict` / `pytest` — not run locally (resource-constrained VM); relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)